### PR TITLE
ci: pin Actions to SHA, add permissions, fix CVE-2020-7660

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -18,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     name: Test before publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 20.x
           cache: "npm"
@@ -30,9 +30,9 @@ jobs:
       contents: read
       id-token: write  # for npm provenance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 20.x
           cache: "npm"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,26 @@
 {
   "name": "ton-wallet-finder",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ton-wallet-finder",
-      "version": "3.0.0",
+      "version": "3.1.0",
+      "funding": [
+        {
+          "type": "cryptocurrency",
+          "url": "https://app.tonkeeper.com/transfer/UQA7h7IS4PvdaWi_0-77XfNRpZSLcDev4erumQpl5fbUJSau"
+        },
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.me/lendelkz"
+        },
+        {
+          "type": "ko_fi",
+          "url": "https://ko-fi.com/lendelkz"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "@ton/crypto": "^3.3.0",
@@ -1821,16 +1835,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1855,35 +1859,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
   "engines": {
     "node": ">=18"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
+  },
   "dependencies": {
     "@ton/crypto": "^3.3.0",
     "@ton/ton": "^16.2.2"


### PR DESCRIPTION
## Changes

### Security: Pin GitHub Actions to immutable SHA hashes
- `actions/checkout@v4` → pinned to `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
- `actions/setup-node@v4` → pinned to `cdca7365b2dadb8aad0a33bc7601856ffabcc48e` (v4.3.0)

Floating tags are mutable and can be overwritten by a compromised repo,
making SHA pinning essential for supply chain security.

### Security: Least-privilege permissions in CI
Added `permissions: contents: read` to the test job in `ci.yml`.

### Fix: CVE-2020-7660 — RCE in serialize-javascript
`mocha 11.7.5` pulls in `serialize-javascript 6.0.2` which allows
code injection via `RegExp.flags` / `Date.prototype.toISOString()`.

Added `overrides` to force `serialize-javascript >=7.0.3` (resolved to
7.0.4). Closes Dependabot alert #13.

All 31 tests pass.