### PR TITLE
fix: 4.0.1 — ESM import, safe result file, bounded retries, reference vectors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     name: Test before publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard
+
+on:
+  push:
+    branches: ["master"]
+  schedule:
+    - cron: '0 6 * * 1'  # every Monday at 06:00 UTC
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b08e1e2e # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,20 +25,20 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b08e1e2e # v2.4.1
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
         with:
           sarif_file: results.sarif

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-test/
-*.log
-.git
-.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [3.2.0] - 2026-03-24
+## [Unreleased]
+
+---
+
+## [4.0.1] — 2026-09-06
+
+### Fixed
+- **ESM import was broken.** `import { TonWalletFinder } from 'ton-wallet-finder'` failed with
+  `ERR_PACKAGE_PATH_NOT_EXPORTED` because the `exports` map had no `import`/`default` condition
+  (regression since 3.1.0). The map now lists `types`, `import`, `require` and `default`.
+  A regression test (`test/esm.test.mjs`) imports the package by name.
+- **`saveResultsToFile` no longer overwrites an existing file.** The file is created with the
+  exclusive `wx` flag; if it already exists a numeric suffix is appended
+  (`ton_wallet_results-2.txt`, `-3`, …). Previously a second run silently destroyed the
+  previously found private key.
+- **`saveResultsToFile` writes to the current working directory** (`process.cwd()`) instead of
+  the directory of the process entry point (`require.main`), which could be inside
+  `node_modules`, an `npx` cache or a read-only location. The function now returns the
+  absolute path of the written file (`Promise<string | undefined>`).
+- **`findWalletWithEnding` no longer retries forever.** After 5 consecutive generation
+  failures it rejects with an Error whose `cause` is the last failure. Transient errors are
+  still retried as before.
+- Cancellation errors now have `name === 'AbortError'` and carry the original
+  `signal.reason` as `cause`, so callers can distinguish cancellation from failure.
+  The error message is unchanged.
+- `targetEnding` longer than 46 characters is rejected at construction time: a TON address
+  has only 46 matchable characters after the `EQ`/`UQ` tag, so such a search could never end.
+- Removed redundant manual padding of the data cell (the `padBits` helper already does it);
+  `Buffer.slice` replaced with `Buffer.subarray`.
 
 ### Added
-- `Readme.md` is now included in the published npm package (`files` field)
-- npm provenance attestation via `--provenance` flag on publish (verifiable on socket.dev and npmjs.com)
+- `test/crypto.test.js`: reference vector (mnemonic → public key → address) produced with
+  `@ton/crypto` and `@ton/ton`, plus unit tests for `cellHash` (empty-cell hash), `padBits`,
+  and `crc16` (CRC-16/XMODEM check value). Any regression in the hand-written crypto now fails
+  the suite instead of producing a valid-looking address that does not belong to the mnemonic.
+- `_internals` export exposing the low-level primitives for testing and advanced use
+  (not yet covered by semver guarantees).
+- `SECURITY.md` with private vulnerability reporting instructions and notes on key handling.
 
-## [3.2.2] - 2026-03-24
-
-### Security
-- All dependency versions pinned to exact values (removed `^` ranges) — eliminates
-  semver drift risk; package installs are now reproducible at the manifest level,
-  not just via the lockfile
-- GitHub Actions steps pinned to commit hashes (already in 3.2.1)
-- npm provenance attestation on publish via `--provenance` (already in 3.2.0)
+### Changed
+- README performance table replaced with measured numbers (about 5 addresses/s per CPU core;
+  the TON mnemonic derivation costs roughly 200 000 HMAC-SHA-512 rounds per candidate).
+- `package-lock.json` regenerated; the previous lock still described version 3.2.1 with
+  `@ton/ton` and `@ton/crypto` as dependencies, which polluted `npm audit` with packages
+  that were not installed.
+- Dev dependency `mocha` upgraded to 12.0.0 (fixes the `serialize-javascript` advisory;
+  the `overrides` entry is no longer needed and was removed).
+- CHANGELOG reordered chronologically; missing 3.2.1 entry added; release dates corrected.
+- CONTRIBUTING now states Node.js 20 (matches `engines`) and points to `SECURITY.md`.
+- Removed `.npmignore` (ineffective and misleading while `files` is set).
+- `publish.yml`: least-privilege `permissions` on the test job.
 
 ---
 
@@ -35,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WalletV4R2 address computation reimplemented as a pure TVM cell-hash algorithm (SHA-256 repr) with a hardcoded code-cell hash/depth constant — no `@ton/core` required
 - CRC-16/CCITT and base64url address encoding done via built-in `Buffer` — no external helpers
 - `wordlist.js` (BIP-39, 2048 words, MIT) added to the published package files
+- Minimum Node.js version raised to 20 (`engines`)
 
 ### Security
 - `saveResultsToFile` now writes with `mode: 0o600` — the output file is no longer world-readable, preventing other local users from reading exported private keys
@@ -52,11 +90,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [3.2.2] — 2026-03-24
+
+### Security
+- All dependency versions pinned to exact values (removed `^` ranges) — eliminates
+  semver drift risk; package installs are now reproducible at the manifest level,
+  not just via the lockfile
 
 ---
 
-## [3.1.0] — 2025-03-24
+## [3.2.1] — 2026-03-24
+
+### Fixed
+- Flaky `console.log` test stabilised by stubbing the crypto helpers
+
+---
+
+## [3.2.0] — 2026-03-24
+
+### Added
+- `Readme.md` is now included in the published npm package (`files` field)
+- npm provenance attestation via `--provenance` flag on publish (verifiable on socket.dev and npmjs.com)
+
+### Infrastructure
+- GitHub Actions steps pinned to commit hashes with least-privilege permissions
+- Automated npm publish workflow on `v*` tags
+
+---
+
+## [3.1.0] — 2026-03-24
 
 ### Added
 - ESLint (`eslint.config.js`) with rules: `no-unused-vars`, `no-undef`, `eqeqeq`, `no-var`, `prefer-const`
@@ -90,7 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [3.0.0] — 2025-03-24
+## [3.0.0] — 2026-02-18
 
 ### Breaking Changes
 - `showResult` parameter default changed from `true` to `false` — library is now silent by default; private keys are not printed to stdout unless explicitly requested

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ cd ton-wallet-finder
 npm install
 ```
 
-**Requirements:** Node.js 18 or higher.
+**Requirements:** Node.js 20 or higher (matches `engines` in `package.json`).
 
 ---
 
@@ -46,9 +46,13 @@ Tests live in `test/TonWalletFinder.test.js` (Mocha + Chai + Sinon).
 `chai` is intentionally pinned to `^4.x` and **must not be upgraded to v5+**.
 Chai v5 dropped CommonJS support. Since this package is a pure CJS library and does not use ESM, upgrading chai would break the test suite without any benefit.
 
-### Dev-dependency note: mocha vulnerabilities
+### Reference vectors
 
-`mocha@11.x` has known vulnerabilities in its own internal dependencies (`diff`, `serialize-javascript`). These are **upstream issues in mocha itself** and do not affect the published package — `npm audit --omit=dev` reports 0 vulnerabilities. The mocha team has not yet released a fix.
+`test/crypto.test.js` pins the mnemonic → key → address derivation to a vector produced with `@ton/crypto` and `@ton/ton`. If you touch anything in the crypto or cell-hashing code and this test goes red, the change is wrong — do not update the vector to make it pass.
+
+### ESM regression test
+
+`test/esm.test.mjs` imports the package **by name** (Node package self-reference) so the `exports` map in `package.json` is exercised exactly as a consumer would. Keep it green when changing `exports`.
 
 ---
 
@@ -76,6 +80,4 @@ Breaking changes include: changing parameter defaults, changing return types, re
 
 ## Security
 
-To report a security vulnerability, please open a [GitHub Issue](https://github.com/lendel/ton-wallet-finder/issues) with the `security` label, or contact the author directly.
-
-Do not disclose security vulnerabilities publicly before a fix is available.
+See [SECURITY.md](SECURITY.md). Please do not report vulnerabilities in public issues.

--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@
 ![CI](https://img.shields.io/github/actions/workflow/status/lendel/ton-wallet-finder/ci.yml?label=CI&style=flat-square)
 ![TypeScript](https://img.shields.io/badge/TypeScript-supported-blue?style=flat-square&logo=typescript)
 ![issues](https://img.shields.io/github/issues/lendel/ton-wallet-finder?style=flat-square)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lendel/ton-wallet-finder/badge)](https://scorecard.dev/viewer/?uri=github.com/lendel/ton-wallet-finder)
 
 **Vanity address generator for TON blockchain.**
 Find a wallet whose address ends with any string you choose.

--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,12 @@ finder.findWalletWithEnding()
   .catch(console.error);
 ```
 
+ES modules work too:
+
+```javascript
+import { TonWalletFinder } from 'ton-wallet-finder';
+```
+
 Run:
 
 ```sh
@@ -79,7 +85,7 @@ node findWallet.js
 | `targetEnding` | `string` | required | Desired address ending. Latin letters, digits, `-`, `_`. **Case-sensitive.** |
 | `showProcess` | `boolean` | `false` | Log each attempted address to console |
 | `showResult` | `boolean` | `false` | Log found wallet details to console. **Keep `false` in shared/logged environments to avoid exposing private keys.** |
-| `saveResult` | `boolean` | `false` | Save result to `ton_wallet_results.txt` |
+| `saveResult` | `boolean` | `false` | Save result to `ton_wallet_results.txt` in the current working directory. Never overwrites: an existing file gets a `-2`, `-3`, … suffix |
 
 ---
 
@@ -115,14 +121,21 @@ TypeScript declarations are included (`index.d.ts`).
 
 ## Performance
 
-Search time grows exponentially with ending length. Rough estimates on a modern CPU:
+Search time grows exponentially with ending length: on average **64ⁿ** candidates for an
+*n*-character ending. Each candidate is expensive by design — a TON mnemonic requires
+about 256 PBKDF2 seed-version checks plus one 100 000-iteration PBKDF2, roughly
+200 000 HMAC-SHA-512 rounds per address. Measured throughput is about **5 addresses per
+second per CPU core** (single-threaded; the library currently uses one core).
 
-| Ending length | ~Attempts | ~Time |
-|--------------|-----------|-------|
-| 1 char | ~64 | instant |
-| 2 chars | ~4 000 | seconds |
-| 3 chars | ~260 000 | minutes |
-| 4 chars | ~16 000 000 | hours |
+| Ending length | Attempts (avg) | Time at ~5 addr/s |
+|--------------|----------------|-------------------|
+| 1 char | 64 | ~12 seconds |
+| 2 chars | 4 096 | ~13 minutes |
+| 3 chars | 262 144 | ~14 hours |
+| 4 chars | 16 777 216 | ~5 weeks |
+
+Estimate: `time ≈ 64ⁿ / 5` seconds. Individual runs vary widely (the attempt count is
+geometrically distributed), so treat these as medians, not guarantees.
 
 > The TON address alphabet is base64url (A–Z, a–z, 0–9, `-`, `_`), so each character position has **64** possible values.
 
@@ -152,11 +165,11 @@ The public API is identical — no code changes required when upgrading from v3.
 
 ### v2/v3 → v4 breaking changes
 
-| What changed | v2 behaviour | v3 behaviour |
+| What changed | v2 behaviour | v3 / v4 behaviour |
 |---|---|---|
 | `showResult` default | `true` — printed private key to stdout by default | `false` — silent by default |
 | `createWallet()` | returned `Promise<Address>` | returns `Address` synchronously |
-| `saveResultsToFile()` | returned `void` (fire-and-forget) | returns `Promise<void>` (awaited) |
+| `saveResultsToFile()` | returned `void` (fire-and-forget) | returns `Promise<string \| undefined>` — the written path (awaited) |
 
 ### Migration checklist
 
@@ -251,7 +264,7 @@ finder.findWalletWithEnding()
 | `targetEnding` | `string` | обязательный | Желаемое окончание адреса. Латиница, цифры, `-`, `_`. **Регистрозависимо.** |
 | `showProcess` | `boolean` | `false` | Выводить каждый проверяемый адрес в консоль |
 | `showResult` | `boolean` | `false` | Вывести найденный кошелёк в консоль. **Оставьте `false` в окружениях с логированием, чтобы не раскрывать приватный ключ.** |
-| `saveResult` | `boolean` | `false` | Сохранить результат в `ton_wallet_results.txt` |
+| `saveResult` | `boolean` | `false` | Сохранить результат в `ton_wallet_results.txt` в текущей рабочей директории. Существующий файл не перезаписывается: добавляется суффикс `-2`, `-3`, … |
 
 ### API
 
@@ -283,14 +296,21 @@ try {
 
 ### Производительность
 
-Время поиска растёт экспоненциально с длиной окончания:
+Время поиска растёт экспоненциально с длиной окончания: в среднем **64ⁿ** кандидатов для
+окончания из *n* символов. Каждый кандидат дорог по самой природе TON-мнемоники: около
+256 проверок seed-версии через PBKDF2 плюс один PBKDF2 на 100 000 итераций, то есть
+порядка 200 000 раундов HMAC-SHA-512 на один адрес. Измеренная скорость — около
+**5 адресов в секунду на одно ядро** (библиотека пока работает в одном потоке).
 
-| Длина окончания | ~Попыток | ~Время |
-|----------------|----------|--------|
-| 1 символ | ~64 | мгновенно |
-| 2 символа | ~4 000 | секунды |
-| 3 символа | ~260 000 | минуты |
-| 4 символа | ~16 000 000 | часы |
+| Длина окончания | Попыток (в среднем) | Время при ~5 адр/с |
+|----------------|---------------------|--------------------|
+| 1 символ | 64 | ~12 секунд |
+| 2 символа | 4 096 | ~13 минут |
+| 3 символа | 262 144 | ~14 часов |
+| 4 символа | 16 777 216 | ~5 недель |
+
+Оценка: `время ≈ 64ⁿ / 5` секунд. Разброс между запусками большой (число попыток
+распределено геометрически), поэтому это медианы, а не гарантии.
 
 ### Что нового в v4
 
@@ -316,7 +336,7 @@ try {
 |---|---|---|
 | Дефолт `showResult` | `true` | `false` |
 | `createWallet()` | `Promise<Address>` | `Address` (синхронно) |
-| `saveResultsToFile()` | `void` | `Promise<void>` |
+| `saveResultsToFile()` | `void` | `Promise<string \| undefined>` — путь к файлу |
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 4.x     | yes       |
+| < 4.0   | no        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Use GitHub's private vulnerability reporting:
+<https://github.com/lendel/ton-wallet-finder/security/advisories/new>
+
+If that is unavailable to you, contact the author directly through the profile
+at <https://github.com/lendel>. You should receive an acknowledgement within
+7 days. Please allow time for a fix and a release before public disclosure.
+
+## What this library does with key material
+
+- It generates mnemonics and Ed25519 keys **locally** using Node.js built-in
+  `crypto`. It has no dependencies and makes no network calls.
+- Private keys and mnemonics are returned to the caller as plain strings.
+  Storing, encrypting and destroying them is the caller's responsibility.
+- With `showResult: true` the private key is printed to stdout. Do not enable
+  this in CI or any environment where stdout is logged.
+- With `saveResult: true` the private key is written **unencrypted** to
+  `ton_wallet_results.txt` in the current working directory, with file mode
+  `0600`. Existing files are never overwritten. Move the key into a wallet and
+  delete the file as soon as possible.
+- JavaScript offers no way to reliably zero memory, so key material may remain
+  in process memory until garbage collection.
+
+## Verifying the implementation
+
+The cryptographic code was rewritten without dependencies in v4.0.0. It is
+checked against reference vectors produced with `@ton/crypto` and `@ton/ton`
+in `test/crypto.test.js`. If you find a mnemonic for which this library and a
+TON wallet disagree on the address, that is a security bug: please report it.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,68 +1,66 @@
 'use strict';
 
+const rules = {
+    'no-unused-vars':        'error',
+    'no-undef':              'error',
+    'no-console':            'off',   // library intentionally uses console for user feedback
+    'no-constant-condition': 'error',
+    'no-duplicate-case':     'error',
+    'no-throw-literal':      'error',
+    'curly':                 ['error', 'all'],
+    'eqeqeq':                ['error', 'always'],
+    'no-var':                'error',
+    'prefer-const':          'error',
+};
+
+const nodeGlobals = {
+    require:         'readonly',
+    module:          'readonly',
+    exports:         'readonly',
+    process:         'readonly',
+    Buffer:          'readonly',
+    console:         'readonly',
+    AbortController: 'readonly',
+    AbortSignal:     'readonly',
+    setTimeout:      'readonly',
+    clearTimeout:    'readonly',
+};
+
+const mochaGlobals = {
+    describe:   'readonly',
+    it:         'readonly',
+    beforeEach: 'readonly',
+    afterEach:  'readonly',
+    before:     'readonly',
+    after:      'readonly',
+};
+
 module.exports = [
     {
-        files: ['index.js'],
+        files: ['index.js', 'eslint.config.js'],
         languageOptions: {
             ecmaVersion: 2022,
             sourceType:  'commonjs',
-            globals: {
-                require:  'readonly',
-                module:   'readonly',
-                exports:  'readonly',
-                process:  'readonly',
-                Buffer:   'readonly',
-                console:  'readonly',
-            },
+            globals:     nodeGlobals,
         },
-        rules: {
-            'no-unused-vars':        'error',
-            'no-undef':              'error',
-            'no-console':            'off',   // library intentionally uses console for user feedback
-            'no-constant-condition': 'error',
-            'no-duplicate-case':     'error',
-            'no-throw-literal':      'error',
-            'curly':                 ['error', 'all'],
-            'eqeqeq':                ['error', 'always'],
-            'no-var':                'error',
-            'prefer-const':          'error',
-        },
+        rules,
     },
     {
         files: ['test/**/*.js'],
         languageOptions: {
             ecmaVersion: 2022,
             sourceType:  'commonjs',
-            globals: {
-                require:       'readonly',
-                module:        'readonly',
-                exports:       'readonly',
-                process:       'readonly',
-                Buffer:        'readonly',
-                console:       'readonly',
-                describe:      'readonly',
-                it:            'readonly',
-                beforeEach:    'readonly',
-                afterEach:     'readonly',
-                before:        'readonly',
-                after:         'readonly',
-                AbortController: 'readonly',
-                AbortSignal:     'readonly',
-                setTimeout:      'readonly',
-                clearTimeout:    'readonly',
-            },
+            globals:     { ...nodeGlobals, ...mochaGlobals },
         },
-        rules: {
-            'no-unused-vars':        'error',
-            'no-undef':              'error',
-            'no-console':            'off',
-            'no-constant-condition': 'error',
-            'no-duplicate-case':     'error',
-            'no-throw-literal':      'error',
-            'curly':                 ['error', 'all'],
-            'eqeqeq':                ['error', 'always'],
-            'no-var':                'error',
-            'prefer-const':          'error',
+        rules,
+    },
+    {
+        files: ['test/**/*.mjs'],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType:  'module',
+            globals:     { ...nodeGlobals, ...mochaGlobals },
         },
+        rules,
     },
 ];

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export interface WalletResult {
     readonly publicKey: string;
     /** Hex-encoded Ed25519 private key / secret key (128 characters) */
     readonly privateKey: string;
-    /** 24-word BIP39 mnemonic seed phrase */
+    /** 24-word TON mnemonic (BIP-39 English word list, TON derivation) */
     readonly words: readonly string[];
     /** TON wallet address in URL-safe bounceable format (e.g. EQ...) */
     readonly walletAddress: string;
@@ -18,8 +18,9 @@ export interface WalletResult {
 export interface FindOptions {
     /**
      * An AbortSignal to cancel the search.
-     * When aborted, `findWalletWithEnding` rejects with an Error whose message
-     * is taken from `signal.reason` (if a string) or `'Wallet search aborted'`.
+     * When aborted, `findWalletWithEnding` rejects with an Error whose `name` is
+     * `'AbortError'`, whose message is taken from `signal.reason` (if a string)
+     * or `'Wallet search aborted'`, and whose `cause` is the original `signal.reason`.
      */
     readonly signal?: AbortSignal;
 }
@@ -55,10 +56,11 @@ export declare class TonWalletFinder {
     /**
      * @param targetEnding - Desired suffix for the wallet address.
      *   Only Latin letters [a-zA-Z], digits [0-9], dashes [-] and underscores [_] are allowed.
+     *   At most 46 characters (a TON address has 46 matchable characters after the `EQ`/`UQ` tag).
      * @param showProcess - Log each attempted address. Default: `false`
      * @param showResult  - Log the found wallet to console. Default: `false`
      * @param saveResult  - Save the result to a text file. Default: `false`
-     * @throws {Error} If `targetEnding` contains invalid characters.
+     * @throws {Error} If `targetEnding` contains invalid characters or is longer than 46 characters.
      */
     constructor(
         targetEnding: string,
@@ -73,14 +75,19 @@ export declare class TonWalletFinder {
     createKeyPair(): Promise<{ keyPair: { publicKey: Uint8Array; secretKey: Uint8Array }; words: string[] }>;
 
     /**
-     * Creates a WalletContractV4 instance from a key pair and returns its address object.
+     * Derives the WalletV4 (workchain 0) address for a key pair and returns an
+     * address object. `toString()` always yields the bounceable, URL-safe form;
+     * the options argument is accepted for compatibility and ignored.
      * Synchronous — no I/O is performed.
      */
-    createWallet(keyPair: { publicKey: Uint8Array; secretKey: Uint8Array }): { toString(opts: { urlSafe: boolean; bounceable: boolean }): string };
+    createWallet(keyPair: { publicKey: Uint8Array; secretKey: Uint8Array }): { toString(opts?: { urlSafe?: boolean; bounceable?: boolean }): string };
 
     /**
      * Continuously generates random wallets until one whose address ends with `targetEnding` is found.
      * Pass `options.signal` to cancel the search at any time.
+     *
+     * Transient key-generation errors are retried; after 5 consecutive failures the
+     * promise rejects with an Error whose `cause` is the last failure.
      *
      * @param options - Optional configuration (e.g. AbortSignal).
      * @returns The found wallet's credentials.
@@ -89,15 +96,19 @@ export declare class TonWalletFinder {
 }
 
 /**
- * Saves wallet credentials to a plain-text file using `fs.promises.writeFile`.
- * The returned Promise resolves once the file has been fully written to disk.
+ * Saves wallet credentials to a plain-text file in the current working directory
+ * (`process.cwd()`), created with mode `0600`.
+ *
+ * Never overwrites: if `fileName` already exists, a numeric suffix is appended
+ * (`ton_wallet_results-2.txt`, `-3`, …).
  *
  * @param publicKey     - Hex-encoded public key.
  * @param privateKey    - Hex-encoded private/secret key.
  * @param words         - Mnemonic seed phrase (array or pre-joined string).
  * @param walletAddress - TON wallet address string.
- * @param fileName      - Output filename. Default: `'ton_wallet_results.txt'`
- * @returns Promise that resolves when the file is written (never rejects — errors are logged).
+ * @param fileName      - Output filename (no path separators). Default: `'ton_wallet_results.txt'`
+ * @returns The absolute path of the written file, or `undefined` if writing failed
+ *          (never rejects — errors are logged).
  */
 export declare function saveResultsToFile(
     publicKey: string,
@@ -105,4 +116,4 @@ export declare function saveResultsToFile(
     words: string[] | string,
     walletAddress: string,
     fileName?: string
-): Promise<void>;
+): Promise<string | undefined>;

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function ed25519FromSeed(seed) {
     const pub         = crypto.createPublicKey(priv);
     // SPKI DER for Ed25519 ends with the 32-byte raw public key.
     const spki        = pub.export({ format: 'der', type: 'spki' });
-    const publicKey   = spki.slice(-32);
+    const publicKey   = spki.subarray(-32);
     // tweetnacl-compatible 64-byte secretKey = seed ‖ publicKey
     const secretKey   = Buffer.concat([seed, publicKey]);
     return { publicKey, secretKey };
@@ -38,7 +38,7 @@ function ed25519FromSeed(seed) {
  * HMAC-SHA-512: key first, then data — matches @ton/crypto hmac_sha512(key, data) convention.
  */
 function hmacSha512(key, data) {
-    return crypto.createHmac('sha512', Buffer.from(key)).update(Buffer.from(data)).digest();
+    return crypto.createHmac('sha512', key).update(data).digest();
 }
 
 /**
@@ -87,7 +87,7 @@ async function mnemonicToPrivateKey(words) {
     const norm    = words.map(w => w.toLowerCase().trim());
     const entropy = hmacSha512(norm.join(' '), '');
     const seed64  = await pbkdf2Sha512(entropy, 'TON default seed', 100000, 64);
-    return ed25519FromSeed(seed64.slice(0, 32));
+    return ed25519FromSeed(seed64.subarray(0, 32));
 }
 
 // ---------------------------------------------------------------------------
@@ -133,7 +133,7 @@ function cellHash(bitsCount, bitsBytes, refs) {
  * and clear the rest of the byte.
  */
 function padBits(bitsCount, bitsBytes) {
-    const result = Buffer.from(bitsBytes.slice(0, Math.ceil(bitsCount / 8)));
+    const result = Buffer.from(bitsBytes.subarray(0, Math.ceil(bitsCount / 8)));
     if (bitsCount % 8 !== 0) {
         const rem     = bitsCount % 8;
         const padMask = 0x80 >> rem;
@@ -144,6 +144,21 @@ function padBits(bitsCount, bitsBytes) {
 }
 
 /**
+ * CRC-16/XMODEM (poly 0x1021, init 0) — the checksum used in TON user-friendly addresses.
+ */
+function crc16(data) {
+    let crc = 0;
+    for (let i = 0; i < data.length; i++) {
+        crc ^= data[i] << 8;
+        for (let j = 0; j < 8; j++) {
+            crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
+        }
+        crc &= 0xffff;
+    }
+    return crc;
+}
+
+/**
  * Derive a WalletV4 (workchain 0) address from a 32-byte Ed25519 public key.
  * Returns a bounceable, URL-safe base64 string (48 chars).
  */
@@ -151,12 +166,11 @@ function walletV4Address(pubkey, workchain = 0) {
     const subwalletId = 698983191 + workchain;
 
     // ---- Data cell: seqno(32) | subwallet_id(32) | pubkey(256) | has_plugins(1) ----
-    // Total = 321 bits; last byte: has_plugins=0 + padding bit 1 + 000000 = 0x40
+    // Total = 321 bits; has_plugins = 0, padBits() sets the trailing "1" completion bit.
     const dataBuf = Buffer.alloc(41, 0);
     dataBuf.writeUInt32BE(0,           0);  // seqno
     dataBuf.writeUInt32BE(subwalletId, 4);  // subwallet_id
     pubkey.copy(dataBuf, 8);                // 32 bytes public key
-    dataBuf[40] = 0x40;                     // padding for the trailing 1 bit
     const dataHash  = cellHash(321, padBits(321, dataBuf), []);
     const dataDepth = 0;
 
@@ -174,14 +188,7 @@ function walletV4Address(pubkey, workchain = 0) {
     addr.writeInt8(workchain, 1);      // workchain (signed byte)
     siHash.copy(addr, 2);
 
-    let crc = 0;
-    for (let i = 0; i < 34; i++) {
-        crc ^= addr[i] << 8;
-        for (let j = 0; j < 8; j++) {
-            crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
-        }
-        crc &= 0xffff;
-    }
+    const crc = crc16(addr.subarray(0, 34));
     addr[34] = (crc >> 8) & 0xff;
     addr[35] =  crc       & 0xff;
 
@@ -191,6 +198,14 @@ function walletV4Address(pubkey, workchain = 0) {
 // ---------------------------------------------------------------------------
 // TonWalletFinder
 // ---------------------------------------------------------------------------
+
+// A user-friendly address is 48 chars and always starts with the 2-char tag
+// ("EQ"/"UQ" for workchain 0), so at most 46 chars can be matched as a suffix.
+const MAX_TARGET_LENGTH = 46;
+
+// Give up after this many *consecutive* failures in key/address generation.
+// Transient errors are retried; a persistent one must not spin forever.
+const MAX_CONSECUTIVE_ERRORS = 5;
 
 class TonWalletFinder {
     /**
@@ -205,6 +220,9 @@ class TonWalletFinder {
         const validEndingRegex = /^[a-zA-Z0-9_-]+$/;
         if (!validEndingRegex.test(targetEnding)) {
             throw new Error('Invalid target ending. Only Latin letters, numbers, dashes, and underscores are allowed.');
+        }
+        if (targetEnding.length > MAX_TARGET_LENGTH) {
+            throw new Error(`Invalid target ending. A TON address has only ${MAX_TARGET_LENGTH} matchable characters, so an ending of ${targetEnding.length} characters can never be found.`);
         }
 
         this.targetEnding = targetEnding;
@@ -245,6 +263,7 @@ class TonWalletFinder {
         // Declared once outside the loop; reused after the loop exits
         let walletAddress;
         let found = false;
+        let consecutiveErrors = 0;
 
         // Search loop — generates wallets until the address suffix matches
         do {
@@ -254,13 +273,22 @@ class TonWalletFinder {
                 const message = typeof reason === 'string'
                     ? reason
                     : reason?.message ?? 'Wallet search aborted';
-                throw new Error(message);
+                const abortError = new Error(message, { cause: reason });
+                abortError.name = 'AbortError';
+                throw abortError;
             }
 
             try {
                 ({ keyPair, words } = await this.createKeyPair());
                 walletAddress = this.createWallet(keyPair).toString({ urlSafe: true, bounceable: true });
+                consecutiveErrors = 0;
             } catch (err) {
+                consecutiveErrors++;
+                if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+                    throw new Error(
+                        `Wallet generation failed ${consecutiveErrors} times in a row, giving up: ${err.message}`,
+                        { cause: err });
+                }
                 console.error('Error generating wallet, retrying:', err.message);
                 continue;
             }
@@ -291,48 +319,78 @@ class TonWalletFinder {
     }
 }
 
+// Upper bound on "name-2.txt", "name-3.txt", … fallbacks before giving up.
+const MAX_FILENAME_ATTEMPTS = 1000;
+
 /**
- * Write wallet credentials to a plain-text file.
- * Uses fs.promises so the write is fully awaited — no data loss on fast exit.
+ * Write wallet credentials to a plain-text file in the current working directory.
+ *
+ * Never overwrites: the file is created with the exclusive `wx` flag, and if a
+ * file with that name already exists a numeric suffix is appended
+ * (`ton_wallet_results-2.txt`, `-3`, …). The file is created with mode 0600.
  *
  * @param {string}          publicKey
  * @param {string}          privateKey
  * @param {string[]|string} words
  * @param {string}          walletAddress
- * @param {string}          [fileName='ton_wallet_results.txt']
- * @returns {Promise<void>}
+ * @param {string}          [fileName='ton_wallet_results.txt'] - plain filename, no path separators
+ * @returns {Promise<string|undefined>} absolute path of the written file, or undefined on error
  */
 async function saveResultsToFile(publicKey, privateKey, words, walletAddress, fileName = 'ton_wallet_results.txt') {
     if (typeof publicKey !== 'string' || typeof privateKey !== 'string' || typeof walletAddress !== 'string') {
         console.error('Error: publicKey, privateKey, and walletAddress must be strings.');
-        return;
+        return undefined;
     }
 
     // Path traversal guard — fileName must be a plain filename, not a path.
-    if (path.basename(fileName) !== fileName) {
+    if (typeof fileName !== 'string' || fileName.length === 0 || path.basename(fileName) !== fileName) {
         console.error('Error: fileName must be a plain filename without path separators.');
-        return;
+        return undefined;
     }
-
-    // require.main can be null in ESM environments and test frameworks
-    const scriptDirectory = require.main
-        ? path.dirname(require.main.filename)
-        : process.cwd();
-    const resultsFile = path.join(scriptDirectory, fileName);
 
     // words may arrive as an array or as an already-joined string
     const wordsString = Array.isArray(words) ? words.join(' ') : words;
     const data = `Public Key: ${publicKey}\nPrivate Key: ${privateKey}\nWords: ${wordsString}\nWallet: ${walletAddress}\n`;
 
+    const ext  = path.extname(fileName);
+    const stem = fileName.slice(0, fileName.length - ext.length);
+    const dir  = process.cwd();
+
     try {
-        await fs.promises.writeFile(resultsFile, data, { mode: 0o600 });
-        console.log(`Results saved to ${resultsFile}`);
+        for (let attempt = 1; attempt <= MAX_FILENAME_ATTEMPTS; attempt++) {
+            const candidate = attempt === 1 ? fileName : `${stem}-${attempt}${ext}`;
+            const resultsFile = path.join(dir, candidate);
+            try {
+                // 'wx' = create only; fails with EEXIST instead of truncating an existing file.
+                await fs.promises.writeFile(resultsFile, data, { mode: 0o600, flag: 'wx' });
+                console.log(`Results saved to ${resultsFile}`);
+                return resultsFile;
+            } catch (err) {
+                if (err.code !== 'EEXIST') { throw err; }
+            }
+        }
+        throw new Error(`Could not find a free filename for ${fileName} after ${MAX_FILENAME_ATTEMPTS} attempts.`);
     } catch (err) {
         console.error('Error while writing results to file:', err);
+        return undefined;
     }
 }
 
+// Kept as a flat identifier list so Node's CJS named-export detection
+// (cjs-module-lexer) picks these up for `import { TonWalletFinder } from ...`.
 module.exports = {
     TonWalletFinder,
     saveResultsToFile,
+};
+
+// Low-level primitives, exposed for testing and advanced use.
+// Not covered by semver guarantees yet; the public surface is the two exports above.
+module.exports._internals = {
+    mnemonicNew,
+    mnemonicToPrivateKey,
+    isBasicSeed,
+    walletV4Address,
+    cellHash,
+    padBits,
+    crc16,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ton-wallet-finder",
-  "version": "3.2.1",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ton-wallet-finder",
-      "version": "3.2.1",
+      "version": "4.0.1",
       "funding": [
         {
           "type": "cryptocurrency",
@@ -22,24 +22,20 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@ton/crypto": "^3.3.0",
-        "@ton/ton": "^16.2.2"
-      },
       "devDependencies": {
-        "chai": "^4.3.7",
-        "eslint": "^10.1.0",
-        "mocha": "^11.7.5",
-        "sinon": "^21.0.3"
+        "chai": "4.3.7",
+        "eslint": "10.1.0",
+        "mocha": "12.0.0",
+        "sinon": "21.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -79,13 +75,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -93,62 +89,23 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -159,9 +116,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -183,25 +140,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -234,35 +205,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -273,10 +215,20 @@
         "type-detect": "4.0.8"
       }
     },
+    "node_modules/@sinonjs/commons/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -294,61 +246,6 @@
         "type-detect": "^4.1.0"
       }
     },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@ton/core": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.63.1.tgz",
-      "integrity": "sha512-hDWMjlKzc18W2E4OeV3hUP8ohRJNHPD4Wd1+AQJj8zshZyCRT0usrvnExgbNUTo/vntDqCGMzgYWbXxyaA+L4g==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@ton/crypto": ">=3.2.0"
-      }
-    },
-    "node_modules/@ton/crypto": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.3.0.tgz",
-      "integrity": "sha512-/A6CYGgA/H36OZ9BbTaGerKtzWp50rg67ZCH2oIjV1NcrBaCK9Z343M+CxedvM7Haf3f/Ee9EhxyeTp0GKMUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ton/crypto-primitives": "2.1.0",
-        "jssha": "3.2.0",
-        "tweetnacl": "1.0.3"
-      }
-    },
-    "node_modules/@ton/crypto-primitives": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.1.0.tgz",
-      "integrity": "sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==",
-      "license": "MIT",
-      "dependencies": {
-        "jssha": "3.2.0"
-      }
-    },
-    "node_modules/@ton/ton": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@ton/ton/-/ton-16.2.2.tgz",
-      "integrity": "sha512-yEOw4IW3gpRZxJAcILMI4dQ1d5/eAAbD2VU/Iwc6z7f2jt1mLDWVED8yn2vLNucQfZr+1eaqYHLztYVFZ7PKmw==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.6.7",
-        "dataloader": "^2.0.0",
-        "zod": "^3.21.4"
-      },
-      "peerDependencies": {
-        "@ton/core": ">=0.63.0 <1.0.0",
-        "@ton/crypto": ">=3.2.0"
-      }
-    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -357,9 +254,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -371,9 +268,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -394,9 +291,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -410,119 +307,59 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "ISC"
     },
     "node_modules/chai": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
       "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -536,165 +373,33 @@
         "node": ">=4"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
       "engines": {
         "node": "*"
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -712,16 +417,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/dataloader": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
-      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -736,23 +435,12 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -767,106 +455,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -874,6 +470,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -967,45 +564,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/espree": {
@@ -1111,6 +669,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -1120,15 +679,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -1146,83 +696,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",
@@ -1234,60 +712,19 @@
         "node": "*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1306,73 +743,14 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/ignore": {
@@ -1405,16 +783,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1438,20 +806,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1466,33 +826,27 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {
@@ -1515,15 +869,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jssha": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.2.0.tgz",
-      "integrity": "sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -1554,6 +899,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -1564,79 +910,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1653,47 +957,42 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-12.0.0.tgz",
+      "integrity": "sha512-NYNh5IFt6WYqm9bi4601m7vix8MZdXC0DwS4gY6WhXO2RgJWhivhISVmq1oklCif18OSI9l+vx5Mdm5oh1XGiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
-        "chokidar": "^4.0.1",
+        "chokidar": "^5.0.0",
         "debug": "^4.3.5",
-        "diff": "^7.0.0",
-        "escape-string-regexp": "^4.0.0",
+        "diff": "^9.0.0",
         "find-up": "^5.0.0",
-        "glob": "^10.4.5",
-        "he": "^1.2.0",
+        "glob": "^13.0.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
+        "is-unicode-supported": "^0.1.0",
+        "js-yaml": "^5.0.0",
+        "minimatch": "^10.2.2",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
-        "serialize-javascript": "^6.0.2",
-        "strip-json-comments": "^3.1.1",
+        "serialize-javascript": "^7.0.2",
+        "strip-json-comments": "^5.0.3",
         "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
-        "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1",
-        "yargs-unparser": "^2.0.0"
+        "workerpool": "^10.0.0"
       },
       "bin": {
-        "_mocha": "bin/_mocha",
         "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -1725,6 +1024,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -1740,6 +1040,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -1750,18 +1051,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1777,17 +1072,17 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1798,6 +1093,7 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -1819,12 +1115,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1836,33 +1126,23 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+      "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1890,19 +1170,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/sinon": {
@@ -1946,117 +1213,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2067,6 +1231,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2076,12 +1241,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2097,10 +1256,11 @@
       }
     },
     "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -2142,225 +1302,23 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-10.0.3.tgz",
+      "integrity": "sha512-6z2Iis68Wqth93/G/wJP9u+R3O+d2XTlgWChGCwuT1qLbBsOYueGRZuJ++v3mtDP5KjYdy+WzvWC+VWETSVXJA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "ton-wallet-finder",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Vanity address generator for TON blockchain — find a WalletV4 address ending with any custom string.",
   "main": "index.js",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
       "require": "./index.js",
-      "types": "./index.d.ts"
+      "default": "./index.js"
     }
   },
   "types": "index.d.ts",
@@ -67,14 +69,10 @@
   "devDependencies": {
     "chai": "4.3.7",
     "eslint": "10.1.0",
-    "mocha": "11.7.5",
+    "mocha": "12.0.0",
     "sinon": "21.0.3"
   },
   "engines": {
     "node": ">=20"
-  },
-  "overrides": {
-    "serialize-javascript": "^7.0.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/test/TonWalletFinder.test.js
+++ b/test/TonWalletFinder.test.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const fs = require('fs');
+const path = require('path');
 const { TonWalletFinder, saveResultsToFile } = require('../index');
 
 describe('TonWalletFinder', () => {
@@ -35,6 +36,14 @@ describe('TonWalletFinder', () => {
 
         it('should throw on targetEnding with special chars like @#$', () => {
             expect(() => new TonWalletFinder('abc!')).to.throw(Error, /Invalid target ending/);
+        });
+
+        it('should accept a 46-character targetEnding (maximum matchable length)', () => {
+            expect(() => new TonWalletFinder('A'.repeat(46))).not.to.throw();
+        });
+
+        it('should throw on targetEnding longer than 46 characters (can never match)', () => {
+            expect(() => new TonWalletFinder('A'.repeat(47))).to.throw(Error, /can never be found/);
         });
 
         it('should default showProcess to false', () => {
@@ -197,6 +206,25 @@ describe('TonWalletFinder', () => {
             }
             expect(caughtError).to.be.instanceOf(Error);
             expect(caughtError.message).to.equal('Search cancelled by test');
+            expect(caughtError.name).to.equal('AbortError');
+            expect(caughtError.cause).to.equal('Search cancelled by test');
+        });
+
+        it('should keep an Error abort reason as cause and use its message', async function () {
+            this.timeout(5000);
+            const controller = new AbortController();
+            const reason = new Error('timeout hit');
+            controller.abort(reason);
+            const finder = new TonWalletFinder('A', false, false, false);
+            let caughtError;
+            try {
+                await finder.findWalletWithEnding({ signal: controller.signal });
+            } catch (err) {
+                caughtError = err;
+            }
+            expect(caughtError.name).to.equal('AbortError');
+            expect(caughtError.message).to.equal('timeout hit');
+            expect(caughtError.cause).to.equal(reason);
         });
 
         it('should reject immediately when an already-aborted signal is passed', async function () {
@@ -249,6 +277,54 @@ describe('TonWalletFinder', () => {
                 stub.restore();
             }
         });
+        // Persistent error: must NOT spin forever
+        it('should reject after repeated consecutive key generation errors', async function () {
+            this.timeout(5000);
+            const finder = new TonWalletFinder('A', false, false, false);
+            const boom = new Error('crypto unavailable');
+            const stub = sinon.stub(finder, 'createKeyPair').rejects(boom);
+            const errorStub = sinon.stub(console, 'error');
+            let caughtError;
+            try {
+                await finder.findWalletWithEnding();
+            } catch (err) {
+                caughtError = err;
+            } finally {
+                stub.restore();
+                errorStub.restore();
+            }
+            expect(caughtError).to.be.instanceOf(Error);
+            expect(caughtError.message).to.include('giving up');
+            expect(caughtError.cause).to.equal(boom);
+            expect(stub.callCount).to.equal(5);
+        });
+
+        it('should reset the consecutive error counter after a successful attempt', async function () {
+            this.timeout(5000);
+            const finder = new TonWalletFinder('A', false, false, false);
+            const fakeKeyPair = { publicKey: Buffer.alloc(32), secretKey: Buffer.alloc(64) };
+            let call = 0;
+            // Pattern: 4 errors, 1 success (no match), 4 errors, 1 success (match).
+            // Never 5 in a row, so the search must complete.
+            const stub = sinon.stub(finder, 'createKeyPair').callsFake(async () => {
+                call++;
+                if (call % 5 !== 0) { throw new Error('flaky'); }
+                return { keyPair: fakeKeyPair, words: Array(24).fill('abandon') };
+            });
+            const walletStub = sinon.stub(finder, 'createWallet')
+                .onFirstCall().returns({ toString: () => 'EQ' + 'B'.repeat(46) })
+                .onSecondCall().returns({ toString: () => 'EQ' + 'A'.repeat(46) });
+            const errorStub = sinon.stub(console, 'error');
+            try {
+                const result = await finder.findWalletWithEnding();
+                expect(result.walletAddress.endsWith('A')).to.equal(true);
+                expect(stub.callCount).to.equal(10);
+            } finally {
+                stub.restore();
+                walletStub.restore();
+                errorStub.restore();
+            }
+        });
     });
 
     // -------------------------------------------------------------------------
@@ -288,6 +364,88 @@ describe('TonWalletFinder', () => {
             await saveResultsToFile('pub', 'priv', ['w1'], 'EQX');
             const [filePath] = writeFileStub.firstCall.args;
             expect(filePath).to.include('ton_wallet_results.txt');
+        });
+
+        it('should write into the current working directory and return the absolute path', async () => {
+            const logStub = sinon.stub(console, 'log');
+            let returned;
+            try {
+                returned = await saveResultsToFile('pub', 'priv', ['w1'], 'EQX', 'out.txt');
+            } finally {
+                logStub.restore();
+            }
+            const expected = path.join(process.cwd(), 'out.txt');
+            expect(returned).to.equal(expected);
+            expect(writeFileStub.firstCall.args[0]).to.equal(expected);
+        });
+
+        it('should create the file exclusively (flag wx) with mode 0600', async () => {
+            const logStub = sinon.stub(console, 'log');
+            try {
+                await saveResultsToFile('pub', 'priv', ['w1'], 'EQX');
+            } finally {
+                logStub.restore();
+            }
+            const opts = writeFileStub.firstCall.args[2];
+            expect(opts).to.include({ mode: 0o600, flag: 'wx' });
+        });
+
+        it('should NOT overwrite an existing file: falls back to a -2 suffix on EEXIST', async () => {
+            const eexist = Object.assign(new Error('exists'), { code: 'EEXIST' });
+            writeFileStub.onFirstCall().rejects(eexist);
+            writeFileStub.onSecondCall().resolves();
+            const logStub = sinon.stub(console, 'log');
+            let returned;
+            try {
+                returned = await saveResultsToFile('pub', 'priv', ['w1'], 'EQX', 'result.txt');
+            } finally {
+                logStub.restore();
+            }
+            expect(writeFileStub.callCount).to.equal(2);
+            expect(writeFileStub.firstCall.args[0]).to.equal(path.join(process.cwd(), 'result.txt'));
+            expect(writeFileStub.secondCall.args[0]).to.equal(path.join(process.cwd(), 'result-2.txt'));
+            expect(returned).to.equal(path.join(process.cwd(), 'result-2.txt'));
+        });
+
+        it('should keep incrementing the suffix while files exist', async () => {
+            const eexist = Object.assign(new Error('exists'), { code: 'EEXIST' });
+            writeFileStub.onCall(0).rejects(eexist);
+            writeFileStub.onCall(1).rejects(eexist);
+            writeFileStub.onCall(2).rejects(eexist);
+            writeFileStub.onCall(3).resolves();
+            const logStub = sinon.stub(console, 'log');
+            let returned;
+            try {
+                returned = await saveResultsToFile('pub', 'priv', ['w1'], 'EQX', 'result.txt');
+            } finally {
+                logStub.restore();
+            }
+            expect(returned).to.equal(path.join(process.cwd(), 'result-4.txt'));
+        });
+
+        it('should return undefined and NOT retry on a non-EEXIST error', async () => {
+            writeFileStub.rejects(Object.assign(new Error('read-only fs'), { code: 'EROFS' }));
+            const consoleErrorStub = sinon.stub(console, 'error');
+            let returned;
+            try {
+                returned = await saveResultsToFile('pub', 'priv', ['w1'], 'EQX');
+            } finally {
+                consoleErrorStub.restore();
+            }
+            expect(returned).to.equal(undefined);
+            expect(writeFileStub.callCount).to.equal(1);
+            expect(consoleErrorStub.calledOnce).to.equal(true);
+        });
+
+        it('should reject an empty fileName', async () => {
+            const consoleErrorStub = sinon.stub(console, 'error');
+            try {
+                const returned = await saveResultsToFile('pub', 'priv', ['w'], 'EQ1', '');
+                expect(returned).to.equal(undefined);
+                expect(writeFileStub.callCount).to.equal(0);
+            } finally {
+                consoleErrorStub.restore();
+            }
         });
 
         it('should log error to console if fs.promises.writeFile rejects', async () => {

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { expect } = require('chai');
+const { _internals } = require('../index');
+
+const { mnemonicToPrivateKey, isBasicSeed, walletV4Address, cellHash, padBits, crc16 } = _internals;
+
+// Reference vector generated with @ton/crypto 3.3 + @ton/ton 16.2 (WalletContractV4, workchain 0).
+// Any change to the mnemonic derivation, cell hashing, padding, CRC or address
+// encoding must keep this test green — otherwise generated addresses would no
+// longer belong to the generated mnemonic.
+const VECTOR = {
+    words: 'tip sadness bid sleep want jaguar upset just crack kid possible heart exclude figure sadness alter feel expect wide have column seek win churn'.split(' '),
+    publicKey: 'f46e86acef393f1546d1f68b2bb090e1a2ed4f3edc112e1e87726364363ad355',
+    address: 'EQCPi7yyyv6aDR8jY38B_PH9wSaMc8NTNEAGgQlnHW_BP3KC',
+};
+
+describe('crypto primitives (reference vectors)', () => {
+
+    describe('package self-reference (exports map)', () => {
+        it('should resolve via require("ton-wallet-finder")', () => {
+            const pkg = require('ton-wallet-finder');
+            expect(pkg.TonWalletFinder).to.be.a('function');
+            expect(pkg.saveResultsToFile).to.be.a('function');
+        });
+    });
+
+    describe('mnemonicToPrivateKey()', () => {
+        it('should derive the reference public key from the reference mnemonic', async function () {
+            this.timeout(10000);
+            const { publicKey, secretKey } = await mnemonicToPrivateKey(VECTOR.words);
+            expect(publicKey.toString('hex')).to.equal(VECTOR.publicKey);
+            // tweetnacl layout: seed ‖ publicKey
+            expect(secretKey).to.have.lengthOf(64);
+            expect(secretKey.subarray(32).toString('hex')).to.equal(VECTOR.publicKey);
+        });
+
+        it('should be case- and whitespace-insensitive', async function () {
+            this.timeout(10000);
+            const messy = VECTOR.words.map((w, i) => i % 2 ? ` ${w.toUpperCase()} ` : w);
+            const { publicKey } = await mnemonicToPrivateKey(messy);
+            expect(publicKey.toString('hex')).to.equal(VECTOR.publicKey);
+        });
+    });
+
+    describe('isBasicSeed()', () => {
+        it('should accept the reference mnemonic', async () => {
+            expect(await isBasicSeed(VECTOR.words)).to.equal(true);
+        });
+
+        it('should reject a mnemonic that fails the seed-version check', async () => {
+            // Swapping two words changes the entropy; with 255/256 probability the
+            // check fails. This specific permutation was verified to fail.
+            const swapped = VECTOR.words.slice();
+            [swapped[0], swapped[1]] = [swapped[1], swapped[0]];
+            expect(await isBasicSeed(swapped)).to.equal(false);
+        });
+    });
+
+    describe('walletV4Address()', () => {
+        it('should produce the reference address from the reference public key', () => {
+            const addr = walletV4Address(Buffer.from(VECTOR.publicKey, 'hex'));
+            expect(addr).to.equal(VECTOR.address);
+        });
+
+        it('should produce a 48-char base64url string with no padding', () => {
+            const addr = walletV4Address(Buffer.alloc(32, 7));
+            expect(addr).to.match(/^[A-Za-z0-9_-]{48}$/);
+        });
+
+        it('should encode a negative workchain as a signed byte', () => {
+            const addr = walletV4Address(Buffer.alloc(32, 7), -1);
+            const raw  = Buffer.from(addr.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+            expect(raw[0]).to.equal(0x11);
+            expect(raw.readInt8(1)).to.equal(-1);
+        });
+    });
+
+    describe('cellHash()', () => {
+        it('should hash the empty cell to the well-known TVM value', () => {
+            // sha256(0x00 0x00) — the canonical empty ordinary cell.
+            const hash = cellHash(0, Buffer.alloc(0), []);
+            expect(hash.toString('hex'))
+                .to.equal('96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7');
+        });
+
+        it('should include ref depths (big-endian) and hashes in the representation', () => {
+            const child = { depth: 0x0102, hash: Buffer.alloc(32, 0xab) };
+            const withRef = cellHash(0, Buffer.alloc(0), [child]);
+            const withOtherDepth = cellHash(0, Buffer.alloc(0), [{ ...child, depth: 0x0201 }]);
+            expect(withRef.toString('hex')).to.not.equal(withOtherDepth.toString('hex'));
+        });
+    });
+
+    describe('padBits()', () => {
+        it('should leave byte-aligned data untouched', () => {
+            const out = padBits(16, Buffer.from([0xff, 0x00]));
+            expect(out.toString('hex')).to.equal('ff00');
+        });
+
+        it('should set the completion bit after 5 data bits (00110 → 0x34)', () => {
+            const out = padBits(5, Buffer.from([0b00110000]));
+            expect(out).to.have.lengthOf(1);
+            expect(out[0]).to.equal(0x34);
+        });
+
+        it('should set the completion bit after 321 data bits (last byte 0x40)', () => {
+            const out = padBits(321, Buffer.alloc(41, 0xff));
+            expect(out).to.have.lengthOf(41);
+            // bit 0 of the last byte is data (1), bit 1 is the completion bit, rest cleared
+            expect(out[40]).to.equal(0b11000000);
+        });
+
+        it('should clear garbage bits beyond the completion bit', () => {
+            const out = padBits(321, Buffer.alloc(41, 0x00).fill(0xff, 40));
+            expect(out[40]).to.equal(0b11000000);
+        });
+    });
+
+    describe('crc16()', () => {
+        it('should match the CRC-16/XMODEM check value for "123456789"', () => {
+            expect(crc16(Buffer.from('123456789'))).to.equal(0x31c3);
+        });
+
+        it('should return 0 for empty input', () => {
+            expect(crc16(Buffer.alloc(0))).to.equal(0);
+        });
+    });
+});

--- a/test/esm.test.mjs
+++ b/test/esm.test.mjs
@@ -1,0 +1,29 @@
+// Regression test for the "exports" map: the package must be importable from
+// ES modules. Uses Node's package self-reference, so this goes through the
+// exact same resolution a consumer's `import ... from 'ton-wallet-finder'` does.
+import chai from 'chai';
+import * as ns from 'ton-wallet-finder';
+import pkg, { TonWalletFinder, saveResultsToFile } from 'ton-wallet-finder';
+
+const { expect } = chai;
+
+describe('ESM import', () => {
+    it('should expose named exports', () => {
+        expect(TonWalletFinder).to.be.a('function');
+        expect(saveResultsToFile).to.be.a('function');
+    });
+
+    it('should expose the same API on the default export', () => {
+        expect(pkg.TonWalletFinder).to.equal(TonWalletFinder);
+        expect(pkg.saveResultsToFile).to.equal(saveResultsToFile);
+    });
+
+    it('should expose the same API on the namespace import', () => {
+        expect(ns.TonWalletFinder).to.equal(TonWalletFinder);
+    });
+
+    it('should construct a finder', () => {
+        const finder = new TonWalletFinder('abc');
+        expect(finder.targetEnding).to.equal('abc');
+    });
+});


### PR DESCRIPTION
## Summary

Patch release addressing the findings of the full project code review. No breaking changes; the public API is unchanged apart from `saveResultsToFile` now returning the written path (`Promise<string | undefined>` instead of `Promise<void>`).

### Fixed
- **ESM import was broken** (`ERR_PACKAGE_PATH_NOT_EXPORTED`): the `exports` map had only `require`/`types`. Now lists `types`, `import`, `require`, `default`. Regression test `test/esm.test.mjs` imports the package by name through Node's package self-reference.
- **`saveResultsToFile` never overwrites**: created with flag `wx`, falls back to `name-2.txt`, `name-3.txt`, … on `EEXIST`. Writes to `process.cwd()` instead of the `require.main` directory (which landed in `node_modules/mocha/bin/` during tests). Returns the absolute path.
- **`findWalletWithEnding` no longer retries forever**: rejects after 5 consecutive generation errors with the last error as `cause`. Transient errors are still retried.
- Abort errors now carry `name: 'AbortError'` and `cause: signal.reason` (message unchanged).
- `targetEnding` longer than 46 characters is rejected at construction (it can never match).
- Redundant manual padding of the data cell removed; `Buffer.slice` → `subarray`.

### Added
- `test/crypto.test.js`: reference vector mnemonic → public key → address produced with `@ton/crypto` + `@ton/ton`, plus unit tests for `cellHash` (canonical empty-cell hash), `padBits` and `crc16` (CRC-16/XMODEM check value). Any regression in the hand-written crypto now fails the suite.
- `_internals` export with the low-level primitives (for tests and advanced use, not yet under semver).
- `SECURITY.md`.

### Changed
- `package-lock.json` regenerated (it still described 3.2.1 with `@ton/*` dependencies, polluting `npm audit` with packages that were not installed).
- mocha 11 → 12 (closes the `serialize-javascript` advisory); the `overrides` entry is gone. `npm audit` is now clean including dev dependencies.
- README performance table replaced with measured numbers (~5 addresses/s per core).
- CHANGELOG reordered, 3.2.1 entry added, dates corrected. CONTRIBUTING says Node 20. `.npmignore` removed. Least-privilege `permissions` on the publish test job. ESLint config deduplicated.

## Verification
- `npm run lint`: clean. `npm test`: 62 passing (was 31).
- Package installed from the tarball into a separate project: ESM named/default import and CJS `require` all work; `tsc --noEmit` passes with `moduleResolution` `node16` and `bundler`.
- `npm pack --dry-run`: same 7 files.
- Crypto parity previously confirmed against `@ton/crypto` and `@ton/ton` on 10/10 generated wallets.

## After merge
Tag `v4.0.1` on `master` to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CywtBeSyR8nr7akwyx5cUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CywtBeSyR8nr7akwyx5cUg)_