### PR TITLE
feat: 4.1.0 — parallel search with worker_threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [4.1.0] — 2026-09-06
+
+### Added
+- **Parallel search.** `findWalletWithEnding({ workers })` runs the search on N
+  `worker_threads` (`'auto'` = one per CPU core) and resolves with the first match; all
+  workers are terminated on match, abort or error. Throughput scales almost linearly with
+  cores. Default stays `1` (single-threaded, unchanged behaviour). Ships as `worker.js`.
+- `FindOptions.workers` in `index.d.ts`; README performance table now shows 1-core and
+  8-core estimates.
+
+### Changed
+- Release process documented in CONTRIBUTING (tag-driven publish, trusted publishing).
+
+---
+
 ## [4.0.1] — 2026-09-06
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,25 @@ Breaking changes include: changing parameter defaults, changing return types, re
 
 ---
 
+## Release Process
+
+Releases are published by CI only (`.github/workflows/publish.yml`), never from a laptop.
+
+1. Merge the release PR into `master` (version bumped in `package.json`, `CHANGELOG.md` updated).
+2. Tag and push:
+   ```sh
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+3. The workflow runs lint + tests, then `npm publish --provenance`.
+
+The workflow currently authenticates with the `NPM_TOKEN` repository secret. The
+recommended setup is npm **trusted publishing** (OIDC, no long-lived token): on
+npmjs.com open the package → Settings → Trusted publisher, and register
+`lendel/ton-wallet-finder` with workflow `publish.yml`. Once that is configured the
+`NODE_AUTH_TOKEN` line can be removed from `publish.yml` and the secret deleted.
+
+---
+
 ## Security
 
 See [SECURITY.md](SECURITY.md). Please do not report vulnerabilities in public issues.

--- a/Readme.md
+++ b/Readme.md
@@ -116,6 +116,19 @@ try {
 }
 ```
 
+**Parallel search** — pass `workers` to use several CPU cores. Throughput scales almost
+linearly with the number of cores:
+
+```javascript
+// one worker thread per CPU core
+const result = await finder.findWalletWithEnding({ workers: 'auto' });
+
+// or an explicit count
+const result = await finder.findWalletWithEnding({ workers: 4 });
+```
+
+`workers` defaults to `1` (single-threaded, same behaviour as before). It can be combined with `signal`.
+
 TypeScript declarations are included (`index.d.ts`).
 
 ---
@@ -126,17 +139,17 @@ Search time grows exponentially with ending length: on average **64ⁿ** candida
 *n*-character ending. Each candidate is expensive by design — a TON mnemonic requires
 about 256 PBKDF2 seed-version checks plus one 100 000-iteration PBKDF2, roughly
 200 000 HMAC-SHA-512 rounds per address. Measured throughput is about **5 addresses per
-second per CPU core** (single-threaded; the library currently uses one core).
+second per CPU core**.
 
-| Ending length | Attempts (avg) | Time at ~5 addr/s |
-|--------------|----------------|-------------------|
-| 1 char | 64 | ~12 seconds |
-| 2 chars | 4 096 | ~13 minutes |
-| 3 chars | 262 144 | ~14 hours |
-| 4 chars | 16 777 216 | ~5 weeks |
+| Ending length | Attempts (avg) | 1 core | 8 cores (`workers: 'auto'`) |
+|--------------|----------------|--------|------------------------------|
+| 1 char | 64 | ~12 seconds | ~2 seconds |
+| 2 chars | 4 096 | ~13 minutes | ~2 minutes |
+| 3 chars | 262 144 | ~14 hours | ~2 hours |
+| 4 chars | 16 777 216 | ~5 weeks | ~5 days |
 
-Estimate: `time ≈ 64ⁿ / 5` seconds. Individual runs vary widely (the attempt count is
-geometrically distributed), so treat these as medians, not guarantees.
+Estimate: `time ≈ 64ⁿ / (5 × cores)` seconds. Individual runs vary widely (the attempt
+count is geometrically distributed), so treat these as medians, not guarantees.
 
 > The TON address alphabet is base64url (A–Z, a–z, 0–9, `-`, `_`), so each character position has **64** possible values.
 
@@ -293,6 +306,19 @@ try {
 }
 ```
 
+**Параллельный поиск** — опция `workers` задействует несколько ядер CPU. Скорость растёт
+почти линейно с числом ядер:
+
+```javascript
+// по одному потоку на ядро
+const result = await finder.findWalletWithEnding({ workers: 'auto' });
+
+// или явное число
+const result = await finder.findWalletWithEnding({ workers: 4 });
+```
+
+По умолчанию `workers: 1` (один поток, прежнее поведение). Сочетается с `signal`.
+
 Поставляется с декларациями TypeScript (`index.d.ts`).
 
 ### Производительность
@@ -301,16 +327,16 @@ try {
 окончания из *n* символов. Каждый кандидат дорог по самой природе TON-мнемоники: около
 256 проверок seed-версии через PBKDF2 плюс один PBKDF2 на 100 000 итераций, то есть
 порядка 200 000 раундов HMAC-SHA-512 на один адрес. Измеренная скорость — около
-**5 адресов в секунду на одно ядро** (библиотека пока работает в одном потоке).
+**5 адресов в секунду на одно ядро**.
 
-| Длина окончания | Попыток (в среднем) | Время при ~5 адр/с |
-|----------------|---------------------|--------------------|
-| 1 символ | 64 | ~12 секунд |
-| 2 символа | 4 096 | ~13 минут |
-| 3 символа | 262 144 | ~14 часов |
-| 4 символа | 16 777 216 | ~5 недель |
+| Длина окончания | Попыток (в среднем) | 1 ядро | 8 ядер (`workers: 'auto'`) |
+|----------------|---------------------|--------|-----------------------------|
+| 1 символ | 64 | ~12 секунд | ~2 секунды |
+| 2 символа | 4 096 | ~13 минут | ~2 минуты |
+| 3 символа | 262 144 | ~14 часов | ~2 часа |
+| 4 символа | 16 777 216 | ~5 недель | ~5 дней |
 
-Оценка: `время ≈ 64ⁿ / 5` секунд. Разброс между запусками большой (число попыток
+Оценка: `время ≈ 64ⁿ / (5 × ядра)` секунд. Разброс между запусками большой (число попыток
 распределено геометрически), поэтому это медианы, а не гарантии.
 
 ### Что нового в v4

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,7 @@ const nodeGlobals = {
     process:         'readonly',
     Buffer:          'readonly',
     console:         'readonly',
+    __dirname:       'readonly',
     AbortController: 'readonly',
     AbortSignal:     'readonly',
     setTimeout:      'readonly',
@@ -37,7 +38,7 @@ const mochaGlobals = {
 
 module.exports = [
     {
-        files: ['index.js', 'eslint.config.js'],
+        files: ['index.js', 'worker.js', 'eslint.config.js'],
         languageOptions: {
             ecmaVersion: 2022,
             sourceType:  'commonjs',

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,13 @@ export interface FindOptions {
      * or `'Wallet search aborted'`, and whose `cause` is the original `signal.reason`.
      */
     readonly signal?: AbortSignal;
+
+    /**
+     * Number of worker threads to search on in parallel, or `'auto'` for one per
+     * available CPU core. Default: `1` (single-threaded, on the main thread).
+     * Throughput scales almost linearly with the number of cores.
+     */
+    readonly workers?: number | 'auto';
 }
 
 /**
@@ -41,6 +48,11 @@ export interface FindOptions {
  * const controller = new AbortController();
  * setTimeout(() => controller.abort(), 30_000); // cancel after 30 s
  * const result = await finder.findWalletWithEnding({ signal: controller.signal });
+ * ```
+ *
+ * @example Parallel search on all CPU cores
+ * ```js
+ * const result = await finder.findWalletWithEnding({ workers: 'auto' });
  * ```
  */
 export declare class TonWalletFinder {
@@ -84,7 +96,8 @@ export declare class TonWalletFinder {
 
     /**
      * Continuously generates random wallets until one whose address ends with `targetEnding` is found.
-     * Pass `options.signal` to cancel the search at any time.
+     * Pass `options.signal` to cancel the search at any time and `options.workers`
+     * to search on several threads in parallel.
      *
      * Transient key-generation errors are retried; after 5 consecutive failures the
      * promise rejects with an Error whose `cause` is the last failure.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@
 
 const crypto = require('crypto');
 const fs     = require('fs');
+const os     = require('os');
 const path   = require('path');
+const { Worker } = require('worker_threads');
 
 const WORDLIST = require('./wordlist');
 
@@ -250,13 +252,25 @@ class TonWalletFinder {
      * Search for a wallet whose address ends with `this.targetEnding`.
      * The comparison is case-sensitive.
      *
-     * @param {object}      [options={}]    - Optional configuration.
-     * @param {AbortSignal} [options.signal] - Optional AbortSignal to cancel the search.
+     * @param {object}      [options={}]     - Optional configuration.
+     * @param {AbortSignal} [options.signal]  - Optional AbortSignal to cancel the search.
+     * @param {number|'auto'} [options.workers=1] - Number of worker threads to search in
+     *        parallel. `'auto'` uses every available CPU core. `1` (default) searches on the
+     *        main thread exactly as before.
      * @returns {Promise<{ publicKey: string, privateKey: string, words: string[], walletAddress: string }>}
      */
     async findWalletWithEnding(options = {}) {
         // Safe destructure — works correctly for both undefined and null
-        const { signal } = options !== null ? options : {};
+        const { signal, workers = 1 } = options !== null ? options : {};
+
+        const workerCount = resolveWorkerCount(workers);
+
+        if (signal?.aborted) { throw abortErrorFrom(signal); }
+
+        if (workerCount > 1) {
+            const { keyPair, words, walletAddress } = await this._searchWithWorkers(workerCount, signal);
+            return this._finish(keyPair, words, walletAddress);
+        }
 
         let keyPair;
         let words;
@@ -268,15 +282,7 @@ class TonWalletFinder {
         // Search loop — generates wallets until the address suffix matches
         do {
             // Honour cancellation at the start of every iteration
-            if (signal?.aborted) {
-                const reason  = signal.reason;
-                const message = typeof reason === 'string'
-                    ? reason
-                    : reason?.message ?? 'Wallet search aborted';
-                const abortError = new Error(message, { cause: reason });
-                abortError.name = 'AbortError';
-                throw abortError;
-            }
+            if (signal?.aborted) { throw abortErrorFrom(signal); }
 
             try {
                 ({ keyPair, words } = await this.createKeyPair());
@@ -300,6 +306,74 @@ class TonWalletFinder {
             found = walletAddress.endsWith(this.targetEnding);
         } while (!found);
 
+        return this._finish(keyPair, words, walletAddress);
+    }
+
+    /**
+     * Run the search on `count` worker threads and resolve with the first match.
+     * All workers are terminated as soon as one finds a match, on abort, or on error.
+     * @private
+     */
+    _searchWithWorkers(count, signal) {
+        return new Promise((resolve, reject) => {
+            const workers = [];
+            let settled = false;
+
+            const shutdown = () => {
+                for (const w of workers) { w.terminate().catch(() => {}); }
+                if (signal) { signal.removeEventListener('abort', onAbort); }
+            };
+            const settle = (fn, value) => {
+                if (settled) { return; }
+                settled = true;
+                shutdown();
+                fn(value);
+            };
+            const onAbort = () => settle(reject, abortErrorFrom(signal));
+
+            if (signal) { signal.addEventListener('abort', onAbort, { once: true }); }
+
+            for (let i = 0; i < count; i++) {
+                const w = this._createWorker({ targetEnding: this.targetEnding, showProcess: this.showProcess });
+                workers.push(w);
+
+                w.on('message', msg => {
+                    if (settled) { return; }
+                    if (msg.type === 'trying') {
+                        console.log('Trying address:', msg.address);
+                    } else if (msg.type === 'found') {
+                        settle(resolve, {
+                            keyPair:       { publicKey: Buffer.from(msg.publicKey), secretKey: Buffer.from(msg.secretKey) },
+                            words:         msg.words,
+                            walletAddress: msg.address,
+                        });
+                    } else if (msg.type === 'error') {
+                        settle(reject, new Error(msg.message));
+                    }
+                });
+                w.on('error', err => settle(reject, err));
+                w.on('exit', code => {
+                    if (!settled && code !== 0) {
+                        settle(reject, new Error(`Search worker exited unexpectedly with code ${code}`));
+                    }
+                });
+            }
+        });
+    }
+
+    /**
+     * Spawn one search worker. Separated so tests can substitute a fake.
+     * @private
+     */
+    _createWorker(workerData) {
+        return new Worker(path.join(__dirname, 'worker.js'), { workerData });
+    }
+
+    /**
+     * Shared tail of the search: format keys, optionally log and save.
+     * @private
+     */
+    async _finish(keyPair, words, walletAddress) {
         // Format keys as hex strings
         const publicKey  = Buffer.from(keyPair.publicKey).toString('hex');
         const privateKey = Buffer.from(keyPair.secretKey).toString('hex');
@@ -317,6 +391,33 @@ class TonWalletFinder {
 
         return { publicKey, privateKey, words, walletAddress };
     }
+}
+
+/**
+ * Build the error thrown when a search is cancelled through an AbortSignal.
+ * `name` is 'AbortError' (platform convention) and `cause` is the original reason.
+ */
+function abortErrorFrom(signal) {
+    const reason  = signal.reason;
+    const message = typeof reason === 'string'
+        ? reason
+        : reason?.message ?? 'Wallet search aborted';
+    const abortError = new Error(message, { cause: reason });
+    abortError.name = 'AbortError';
+    return abortError;
+}
+
+/**
+ * Validate the `workers` option: a positive integer, or 'auto' for one per CPU core.
+ */
+function resolveWorkerCount(workers) {
+    if (workers === 'auto') {
+        return typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length;
+    }
+    if (!Number.isInteger(workers) || workers < 1) {
+        throw new RangeError(`Invalid workers option: expected a positive integer or 'auto', got ${JSON.stringify(workers)}`);
+    }
+    return workers;
 }
 
 // Upper bound on "name-2.txt", "name-3.txt", … fallbacks before giving up.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ton-wallet-finder",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Vanity address generator for TON blockchain — find a WalletV4 address ending with any custom string.",
   "main": "index.js",
   "exports": {
@@ -17,7 +17,8 @@
     "wordlist.js",
     "index.d.ts",
     "CHANGELOG.md",
-    "Readme.md"
+    "Readme.md",
+    "worker.js"
   ],
   "sideEffects": false,
   "scripts": {

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { EventEmitter } = require('events');
+const { TonWalletFinder } = require('../index');
+
+/**
+ * Minimal stand-in for worker_threads.Worker: an EventEmitter with the two
+ * methods the finder uses. Tests drive it by emitting 'message'/'error'/'exit'.
+ */
+function fakeWorker() {
+    const w = new EventEmitter();
+    w.terminated = false;
+    w.terminate = sinon.stub().callsFake(() => { w.terminated = true; return Promise.resolve(0); });
+    return w;
+}
+
+describe('findWalletWithEnding({ workers })', () => {
+
+    describe('option validation', () => {
+        it('should reject workers: 0', async () => {
+            const finder = new TonWalletFinder('A');
+            let err;
+            try { await finder.findWalletWithEnding({ workers: 0 }); } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(RangeError);
+        });
+
+        it('should reject non-integer and negative workers', async () => {
+            const finder = new TonWalletFinder('A');
+            for (const bad of [1.5, -2, '4', null, NaN]) {
+                let err;
+                try { await finder.findWalletWithEnding({ workers: bad }); } catch (e) { err = e; }
+                expect(err, `workers=${bad}`).to.be.instanceOf(RangeError);
+            }
+        });
+
+        it('should treat workers: 1 as the single-threaded path (no worker spawned)', async () => {
+            const finder = new TonWalletFinder('A');
+            const spawn = sinon.stub(finder, '_createWorker');
+            sinon.stub(finder, 'createKeyPair')
+                .resolves({ keyPair: { publicKey: Buffer.alloc(32), secretKey: Buffer.alloc(64) }, words: Array(24).fill('abandon') });
+            sinon.stub(finder, 'createWallet').returns({ toString: () => 'EQ' + 'A'.repeat(46) });
+            try {
+                await finder.findWalletWithEnding({ workers: 1 });
+                expect(spawn.callCount).to.equal(0);
+            } finally {
+                sinon.restore();
+            }
+        });
+    });
+
+    describe('with fake workers (deterministic)', () => {
+        let finder;
+        let spawned;
+
+        beforeEach(() => {
+            finder  = new TonWalletFinder('A');
+            spawned = [];
+            sinon.stub(finder, '_createWorker').callsFake(workerData => {
+                const w = fakeWorker();
+                w.workerData = workerData;
+                spawned.push(w);
+                return w;
+            });
+        });
+
+        afterEach(() => sinon.restore());
+
+        it('should spawn exactly `workers` workers with targetEnding and showProcess', async () => {
+            const p = finder.findWalletWithEnding({ workers: 3 });
+            expect(spawned).to.have.lengthOf(3);
+            expect(spawned[0].workerData).to.deep.equal({ targetEnding: 'A', showProcess: false });
+            spawned[1].emit('message', {
+                type: 'found', publicKey: Buffer.alloc(32, 1), secretKey: Buffer.alloc(64, 2),
+                words: Array(24).fill('abandon'), address: 'EQ' + 'A'.repeat(46),
+            });
+            const result = await p;
+            expect(result.walletAddress).to.equal('EQ' + 'A'.repeat(46));
+            expect(result.publicKey).to.equal('01'.repeat(32));
+            expect(result.privateKey).to.equal('02'.repeat(64));
+            expect(result.words).to.have.lengthOf(24);
+        });
+
+        it('should terminate every worker once one reports a match', async () => {
+            const p = finder.findWalletWithEnding({ workers: 4 });
+            spawned[2].emit('message', {
+                type: 'found', publicKey: new Uint8Array(32), secretKey: new Uint8Array(64),
+                words: [], address: 'EQA',
+            });
+            await p;
+            for (const w of spawned) { expect(w.terminated).to.equal(true); }
+        });
+
+        it('should ignore a second match after the first one settled', async () => {
+            const p = finder.findWalletWithEnding({ workers: 2 });
+            const found = addr => ({ type: 'found', publicKey: new Uint8Array(32), secretKey: new Uint8Array(64), words: [], address: addr });
+            spawned[0].emit('message', found('EQ1A'));
+            spawned[1].emit('message', found('EQ2A'));
+            const result = await p;
+            expect(result.walletAddress).to.equal('EQ1A');
+        });
+
+        it('should log "Trying address:" for worker progress messages when showProcess is true', async () => {
+            finder.showProcess = true;
+            const logStub = sinon.stub(console, 'log');
+            const p = finder.findWalletWithEnding({ workers: 2 });
+            expect(spawned[0].workerData.showProcess).to.equal(true);
+            spawned[0].emit('message', { type: 'trying', address: 'EQxyz' });
+            spawned[1].emit('message', { type: 'found', publicKey: new Uint8Array(32), secretKey: new Uint8Array(64), words: [], address: 'EQA' });
+            await p;
+            const trying = logStub.getCalls().filter(c => c.args[0] === 'Trying address:');
+            expect(trying).to.have.lengthOf(1);
+            expect(trying[0].args[1]).to.equal('EQxyz');
+        });
+
+        it('should reject and terminate all workers when a worker reports a persistent error', async () => {
+            const p = finder.findWalletWithEnding({ workers: 2 });
+            spawned[0].emit('message', { type: 'error', message: 'giving up: crypto unavailable' });
+            let err;
+            try { await p; } catch (e) { err = e; }
+            expect(err).to.be.instanceOf(Error);
+            expect(err.message).to.include('giving up');
+            for (const w of spawned) { expect(w.terminated).to.equal(true); }
+        });
+
+        it('should reject when a worker throws (error event)', async () => {
+            const p = finder.findWalletWithEnding({ workers: 2 });
+            spawned[1].emit('error', new Error('worker crashed'));
+            let err;
+            try { await p; } catch (e) { err = e; }
+            expect(err.message).to.equal('worker crashed');
+        });
+
+        it('should reject when a worker exits with a non-zero code before finding anything', async () => {
+            const p = finder.findWalletWithEnding({ workers: 2 });
+            spawned[0].emit('exit', 1);
+            let err;
+            try { await p; } catch (e) { err = e; }
+            expect(err.message).to.include('exited unexpectedly');
+        });
+
+        it('should reject with AbortError and terminate workers on abort', async () => {
+            const controller = new AbortController();
+            const p = finder.findWalletWithEnding({ workers: 2, signal: controller.signal });
+            controller.abort('stop now');
+            let err;
+            try { await p; } catch (e) { err = e; }
+            expect(err.name).to.equal('AbortError');
+            expect(err.message).to.equal('stop now');
+            for (const w of spawned) { expect(w.terminated).to.equal(true); }
+        });
+
+        it('should reject immediately on an already-aborted signal without spawning workers', async () => {
+            const controller = new AbortController();
+            controller.abort('pre');
+            let err;
+            try { await finder.findWalletWithEnding({ workers: 2, signal: controller.signal }); } catch (e) { err = e; }
+            expect(err.name).to.equal('AbortError');
+            expect(spawned).to.have.lengthOf(0);
+        });
+
+        it('should still call saveResultsToFile when saveResult is true', async () => {
+            finder.saveResult = true;
+            const fs = require('fs');
+            const writeFileStub = sinon.stub(fs.promises, 'writeFile').resolves();
+            const logStub = sinon.stub(console, 'log');
+            const p = finder.findWalletWithEnding({ workers: 2 });
+            spawned[0].emit('message', { type: 'found', publicKey: new Uint8Array(32), secretKey: new Uint8Array(64), words: ['w'], address: 'EQA' });
+            await p;
+            expect(writeFileStub.calledOnce).to.equal(true);
+            expect(writeFileStub.firstCall.args[1]).to.include('Wallet: EQA');
+            logStub.restore();
+        });
+    });
+
+    describe('with real worker threads (integration)', () => {
+        it('should find a matching address using 2 workers', async function () {
+            this.timeout(60000);
+            const finder = new TonWalletFinder('A');
+            const result = await finder.findWalletWithEnding({ workers: 2 });
+            expect(result.walletAddress).to.have.lengthOf(48);
+            expect(result.walletAddress.endsWith('A')).to.equal(true);
+            expect(result.publicKey).to.match(/^[0-9a-f]{64}$/);
+            expect(result.privateKey).to.match(/^[0-9a-f]{128}$/);
+            expect(result.words).to.have.lengthOf(24);
+        });
+
+        it('should stop real workers on abort (process must not hang)', async function () {
+            this.timeout(10000);
+            const finder = new TonWalletFinder('AAAAAAAAAA');
+            const controller = new AbortController();
+            setTimeout(() => controller.abort('timeout'), 200);
+            let err;
+            try { await finder.findWalletWithEnding({ workers: 2, signal: controller.signal }); } catch (e) { err = e; }
+            expect(err.name).to.equal('AbortError');
+        });
+
+        it("should accept workers: 'auto'", async function () {
+            this.timeout(60000);
+            const finder = new TonWalletFinder('A');
+            const result = await finder.findWalletWithEnding({ workers: 'auto' });
+            expect(result.walletAddress.endsWith('A')).to.equal(true);
+        });
+    });
+});

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// Worker-thread entry point for TonWalletFinder's parallel search.
+//
+// Each worker runs an independent generate-and-check loop and reports back to
+// the main thread through parentPort:
+//   { type: 'trying', address }                       (only when showProcess)
+//   { type: 'found', publicKey, secretKey, words, address }
+//   { type: 'error', message }                       (after repeated failures)
+// The main thread terminates all workers as soon as one of them reports 'found'.
+
+const { parentPort, workerData, isMainThread } = require('worker_threads');
+const { _internals } = require('./index');
+
+const { mnemonicNew, mnemonicToPrivateKey, walletV4Address } = _internals;
+
+// Same policy as the single-threaded loop in index.js.
+const MAX_CONSECUTIVE_ERRORS = 5;
+
+async function searchLoop({ targetEnding, showProcess }) {
+    let consecutiveErrors = 0;
+    while (true) {
+        let keyPair;
+        let words;
+        let address;
+        try {
+            words   = await mnemonicNew();
+            keyPair = await mnemonicToPrivateKey(words);
+            address = walletV4Address(keyPair.publicKey);
+            consecutiveErrors = 0;
+        } catch (err) {
+            consecutiveErrors++;
+            if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+                parentPort.postMessage({
+                    type:    'error',
+                    message: `Wallet generation failed ${consecutiveErrors} times in a row, giving up: ${err.message}`,
+                });
+                return;
+            }
+            continue;
+        }
+
+        if (showProcess) {
+            parentPort.postMessage({ type: 'trying', address });
+        }
+
+        if (address.endsWith(targetEnding)) {
+            parentPort.postMessage({
+                type:      'found',
+                publicKey: keyPair.publicKey,
+                secretKey: keyPair.secretKey,
+                words,
+                address,
+            });
+            return;
+        }
+    }
+}
+
+if (!isMainThread && parentPort) {
+    searchLoop(workerData).catch(err => {
+        parentPort.postMessage({ type: 'error', message: err.message });
+    });
+}
+
+module.exports = { searchLoop };


### PR DESCRIPTION
## Summary

Adds parallel search, the single biggest performance improvement identified in the code review. The TON mnemonic derivation is inherently expensive (~200 000 HMAC-SHA-512 rounds per candidate, ~5 addresses/s per core) and cannot be sped up, but the search is embarrassingly parallel and the library previously used one core.

### Added
- `findWalletWithEnding({ workers })`: `N` worker threads or `'auto'` (one per CPU core). Resolves with the first match; every worker is terminated on match, abort, or error. Abort rejects with the same `AbortError` as the single-threaded path.
- Default remains `workers: 1`, so existing callers and their stubs on `createKeyPair` / `createWallet` are unaffected.
- `worker.js` (added to `files`): the worker entry point, reusing the exported `_internals` primitives.
- `FindOptions.workers` in `index.d.ts`; README (EN/RU) usage plus a 1-core vs 8-core performance table.
- CONTRIBUTING: release process (tag-driven publish, how to switch to npm trusted publishing).

### Implementation notes
- The main loop's tail (hex formatting, `showResult`, `saveResult`) is extracted into `_finish()` and shared by both paths.
- `_createWorker()` is the seam tests use to inject fake `EventEmitter` workers, so the pool logic (first-match wins, terminate-all, error/exit handling, abort listener cleanup) is covered deterministically. Three integration tests use real threads, including an abort test that would hang mocha if workers leaked.

## Verification
- `npm run lint` clean; `npm test` 78 passing (was 62).
- Smoke run on 4 vCPU: 1-char search with `workers: 4` in 1.9 s (vs ~12 s single-threaded); process exits cleanly after abort.
- `npm pack --dry-run`: 8 files (worker.js added).

## After merge
Tag `v4.1.0` on `master` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CywtBeSyR8nr7akwyx5cUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CywtBeSyR8nr7akwyx5cUg)_