### PR TITLE
docs: align docs with 4.1.0; CI on Node 20/22/24/26, publish on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: "npm"
 
       - run: npm ci
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   8-core estimates.
 
 ### Changed
+- CI matrix now covers Node.js 20, 22, 24 and 26; the publish workflow runs on Node.js 24
+  (Active LTS). Node.js 20 reached end-of-life on 2026-04-30 and remains supported only until
+  the next major release; README and CONTRIBUTING say so.
+- `npm run lint` now also lints `worker.js`.
+- `_internals` is declared in `index.d.ts`; `walletV4Address` and `cellHash` accept any
+  `Uint8Array`, not only `Buffer`.
 - Release process documented in CONTRIBUTING (tag-driven publish, trusted publishing).
+
+### Documentation
+- README: `saveResultsToFile`, `createKeyPair`, `createWallet` and `_internals` documented;
+  cancellation errors described (`name: 'AbortError'`, `cause`); retry limit described;
+  `targetEnding` length limit added to the options table; ES-module example added to the
+  Russian section; the checksum is correctly named CRC-16/XMODEM (not CRC-16/CCITT); the
+  migration table distinguishes the v3 and 4.0.1 return types of `saveResultsToFile`.
+- The "network access" scanner note in the README no longer blames the funding links; the
+  stale lock file that listed `axios` was the more likely cause and is gone since 4.0.1.
 
 ---
 
@@ -73,6 +88,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING now states Node.js 20 (matches `engines`) and points to `SECURITY.md`.
 - Removed `.npmignore` (ineffective and misleading while `files` is set).
 - `publish.yml`: least-privilege `permissions` on the test job.
+
+### Infrastructure
+- OpenSSF Scorecard workflow (weekly and on push to `master`), all actions pinned to
+  verified commit SHAs; badge in README.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ cd ton-wallet-finder
 npm install
 ```
 
-**Requirements:** Node.js 20 or higher (matches `engines` in `package.json`).
+**Requirements:** Node.js 20 or higher (matches `engines` in `package.json`). Develop on
+Node.js 22 or 24 (LTS); CI runs the suite on 20, 22, 24 and 26. Node.js 20 is end-of-life
+(30 April 2026) and is kept only until the next major release.
 
 ---
 
@@ -21,7 +23,7 @@ npm install
 | Command | Description |
 |---------|-------------|
 | `npm test` | Run the full test suite (Mocha) |
-| `npm run lint` | Run ESLint on `index.js` and `test/` |
+| `npm run lint` | Run ESLint on `index.js`, `worker.js` and `test/` |
 
 ---
 
@@ -35,7 +37,14 @@ npm install
 
 ## Testing
 
-Tests live in `test/TonWalletFinder.test.js` (Mocha + Chai + Sinon).
+Tests live in `test/` (Mocha + Chai + Sinon):
+
+| File | Covers |
+|------|--------|
+| `TonWalletFinder.test.js` | Constructor validation, single-threaded search, cancellation, `saveResultsToFile` |
+| `workers.test.js` | Worker-thread pool (deterministic fake workers + real-thread integration) |
+| `crypto.test.js` | Reference vectors for mnemonic → key → address, `cellHash`, `padBits`, `crc16` |
+| `esm.test.mjs` | Package is importable from ES modules through the `exports` map |
 
 - Every new feature or bug fix must include a corresponding test
 - All stubs must be restored (use `try/finally` with `stub.restore()`)
@@ -43,7 +52,7 @@ Tests live in `test/TonWalletFinder.test.js` (Mocha + Chai + Sinon).
 
 ### Dev-dependency note: Chai v4
 
-`chai` is intentionally pinned to `^4.x` and **must not be upgraded to v5+**.
+`chai` is intentionally pinned to `4.3.7` and **must not be upgraded to v5+**.
 Chai v5 dropped CommonJS support. Since this package is a pure CJS library and does not use ESM, upgrading chai would break the test suite without any benefit.
 
 ### Reference vectors
@@ -87,7 +96,7 @@ Releases are published by CI only (`.github/workflows/publish.yml`), never from 
    ```sh
    git tag vX.Y.Z && git push origin vX.Y.Z
    ```
-3. The workflow runs lint + tests, then `npm publish --provenance`.
+3. The workflow runs lint + tests on Node.js 24, then `npm publish --provenance`.
 
 The workflow currently authenticates with the `NPM_TOKEN` repository secret. The
 recommended setup is npm **trusted publishing** (OIDC, no long-lived token): on

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023–2025 Andrey Voanerges
+Copyright (c) 2023–2026 Andrey Voanerges
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ Find a wallet whose address ends with any string you choose.
 
 ---
 
-**Security: 0 dependencies, 0 network calls. Verified pure logic. The "Network access" flag in some scanners is a false positive caused by the funding links in package.json.**
+**Security: 0 dependencies, 0 network calls.** The only modules imported are Node.js built-ins (`crypto`, `fs`, `os`, `path`, `worker_threads`) — verify with `grep require index.js worker.js`. Every npm release is published from CI with a provenance attestation.
 
 ---
 
@@ -43,7 +43,7 @@ Find a wallet whose address ends with any string you choose.
 npm install ton-wallet-finder
 ```
 
-> Requires Node.js 20 or higher.
+> Requires Node.js 20 or higher. **Node.js 22 or 24 (LTS) is recommended**: Node.js 20 reached end-of-life on 30 April 2026 and support for it will be dropped in the next major release.
 
 ---
 
@@ -83,7 +83,7 @@ node findWallet.js
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `targetEnding` | `string` | required | Desired address ending. Latin letters, digits, `-`, `_`. **Case-sensitive.** |
+| `targetEnding` | `string` | required | Desired address ending. Latin letters, digits, `-`, `_`, at most 46 characters. **Case-sensitive.** |
 | `showProcess` | `boolean` | `false` | Log each attempted address to console |
 | `showResult` | `boolean` | `false` | Log found wallet details to console. **Keep `false` in shared/logged environments to avoid exposing private keys.** |
 | `saveResult` | `boolean` | `false` | Save result to `ton_wallet_results.txt` in the current working directory. Never overwrites: an existing file gets a `-2`, `-3`, … suffix |
@@ -112,9 +112,14 @@ setTimeout(() => controller.abort('timeout'), 30_000); // cancel after 30 s
 try {
   const result = await finder.findWalletWithEnding({ signal: controller.signal });
 } catch (err) {
-  console.log('Search cancelled:', err.message);
+  if (err.name === 'AbortError') {
+    console.log('Search cancelled:', err.message); // err.cause === signal.reason
+  }
 }
 ```
+
+If key generation fails 5 times in a row (for example, a runtime without Ed25519 support),
+the promise rejects with the last error as `cause` instead of retrying forever.
 
 **Parallel search** — pass `workers` to use several CPU cores. Throughput scales almost
 linearly with the number of cores:
@@ -128,6 +133,25 @@ const result = await finder.findWalletWithEnding({ workers: 4 });
 ```
 
 `workers` defaults to `1` (single-threaded, same behaviour as before). It can be combined with `signal`.
+
+### `saveResultsToFile(publicKey, privateKey, words, walletAddress, [fileName]) → Promise<string | undefined>`
+
+Writes the credentials as plain text to `fileName` (default `ton_wallet_results.txt`) in the
+**current working directory**, with file mode `0600`. Never overwrites: if the file exists, a
+numeric suffix is appended (`ton_wallet_results-2.txt`, `-3`, …). Resolves with the absolute
+path of the written file, or `undefined` if writing failed (the error is logged, never thrown).
+`fileName` must be a plain file name — path separators are rejected. This is what
+`saveResult: true` calls internally.
+
+### Lower-level methods
+
+- `finder.createKeyPair()` → `Promise<{ keyPair: { publicKey, secretKey }, words }>` — a fresh
+  24-word TON mnemonic and its Ed25519 key pair.
+- `finder.createWallet(keyPair)` → object whose `toString()` returns the bounceable, URL-safe
+  WalletV4 address (synchronous).
+- `_internals` — the primitives behind the above (`mnemonicNew`, `mnemonicToPrivateKey`,
+  `isBasicSeed`, `walletV4Address`, `cellHash`, `padBits`, `crc16`). Exported for testing and
+  advanced use; not yet covered by semver guarantees.
 
 TypeScript declarations are included (`index.d.ts`).
 
@@ -168,7 +192,7 @@ Starting with v4, everything is implemented using **Node.js built-in modules onl
 | Mnemonic generation | `crypto.randomBytes` + bundled BIP-39 word list |
 | HMAC-SHA-512 / PBKDF2-SHA-512 | `crypto.createHmac` / `crypto.pbkdf2` |
 | Ed25519 key derivation | `crypto.createPrivateKey` with PKCS#8 seed wrapping |
-| WalletV4R2 address | TVM cell hash (SHA-256) + CRC-16/CCITT via `Buffer` |
+| WalletV4R2 address | TVM cell hash (SHA-256) + CRC-16/XMODEM via `Buffer` |
 
 **Result:** `npm install ton-wallet-finder` now installs **0 additional packages**.
 The public API is identical — no code changes required when upgrading from v3.
@@ -183,7 +207,7 @@ The public API is identical — no code changes required when upgrading from v3.
 |---|---|---|
 | `showResult` default | `true` — printed private key to stdout by default | `false` — silent by default |
 | `createWallet()` | returned `Promise<Address>` | returns `Address` synchronously |
-| `saveResultsToFile()` | returned `void` (fire-and-forget) | returns `Promise<string \| undefined>` — the written path (awaited) |
+| `saveResultsToFile()` | returned `void` (fire-and-forget) | v3: `Promise<void>`; 4.0.1+: `Promise<string \| undefined>` — the written path |
 
 ### Migration checklist
 
@@ -251,7 +275,7 @@ Thank you for your support! 💙
 npm install ton-wallet-finder
 ```
 
-> Требуется Node.js 20 или выше.
+> Требуется Node.js 20 или выше. **Рекомендуется Node.js 22 или 24 (LTS)**: поддержка Node.js 20 закончилась 30 апреля 2026 года, и в следующей мажорной версии она будет убрана.
 
 ### Быстрый старт
 
@@ -271,11 +295,17 @@ finder.findWalletWithEnding()
   .catch(console.error);
 ```
 
+ES-модули тоже поддерживаются:
+
+```javascript
+import { TonWalletFinder } from 'ton-wallet-finder';
+```
+
 ### Опции
 
 | Параметр | Тип | По умолчанию | Описание |
 |----------|-----|--------------|----------|
-| `targetEnding` | `string` | обязательный | Желаемое окончание адреса. Латиница, цифры, `-`, `_`. **Регистрозависимо.** |
+| `targetEnding` | `string` | обязательный | Желаемое окончание адреса. Латиница, цифры, `-`, `_`, не более 46 символов. **Регистрозависимо.** |
 | `showProcess` | `boolean` | `false` | Выводить каждый проверяемый адрес в консоль |
 | `showResult` | `boolean` | `false` | Вывести найденный кошелёк в консоль. **Оставьте `false` в окружениях с логированием, чтобы не раскрывать приватный ключ.** |
 | `saveResult` | `boolean` | `false` | Сохранить результат в `ton_wallet_results.txt` в текущей рабочей директории. Существующий файл не перезаписывается: добавляется суффикс `-2`, `-3`, … |
@@ -302,9 +332,14 @@ setTimeout(() => controller.abort('таймаут'), 30_000); // отмена ч
 try {
   const result = await finder.findWalletWithEnding({ signal: controller.signal });
 } catch (err) {
-  console.log('Поиск отменён:', err.message);
+  if (err.name === 'AbortError') {
+    console.log('Поиск отменён:', err.message); // err.cause === signal.reason
+  }
 }
 ```
+
+Если генерация ключа падает 5 раз подряд (например, рантайм без поддержки Ed25519),
+промис отклоняется с последней ошибкой в `cause`, а не крутится бесконечно.
 
 **Параллельный поиск** — опция `workers` задействует несколько ядер CPU. Скорость растёт
 почти линейно с числом ядер:
@@ -318,6 +353,25 @@ const result = await finder.findWalletWithEnding({ workers: 4 });
 ```
 
 По умолчанию `workers: 1` (один поток, прежнее поведение). Сочетается с `signal`.
+
+#### `saveResultsToFile(publicKey, privateKey, words, walletAddress, [fileName]) → Promise<string | undefined>`
+
+Записывает данные кошелька открытым текстом в `fileName` (по умолчанию `ton_wallet_results.txt`)
+в **текущей рабочей директории** с правами `0600`. Никогда не перезаписывает: если файл существует,
+добавляется числовой суффикс (`ton_wallet_results-2.txt`, `-3`, …). Возвращает абсолютный путь
+записанного файла или `undefined`, если запись не удалась (ошибка логируется, не выбрасывается).
+`fileName` должен быть простым именем файла — разделители пути отклоняются. Именно эту функцию
+вызывает `saveResult: true`.
+
+#### Низкоуровневые методы
+
+- `finder.createKeyPair()` → `Promise<{ keyPair: { publicKey, secretKey }, words }>` — новая
+  24-словная TON-мнемоника и её пара ключей Ed25519.
+- `finder.createWallet(keyPair)` → объект, чей `toString()` возвращает bounceable URL-safe
+  адрес WalletV4 (синхронно).
+- `_internals` — примитивы, на которых всё построено (`mnemonicNew`, `mnemonicToPrivateKey`,
+  `isBasicSeed`, `walletV4Address`, `cellHash`, `padBits`, `crc16`). Экспортированы для тестов и
+  продвинутого использования; пока не покрыты гарантиями semver.
 
 Поставляется с декларациями TypeScript (`index.d.ts`).
 
@@ -352,7 +406,7 @@ const result = await finder.findWalletWithEnding({ workers: 4 });
 | Генерация мнемоники | `crypto.randomBytes` + встроенный список BIP-39 |
 | HMAC-SHA-512 / PBKDF2-SHA-512 | `crypto.createHmac` / `crypto.pbkdf2` |
 | Деривация ключа Ed25519 | `crypto.createPrivateKey` с обёрткой PKCS#8 |
-| Адрес WalletV4R2 | Хэш TVM-ячейки (SHA-256) + CRC-16/CCITT через `Buffer` |
+| Адрес WalletV4R2 | Хэш TVM-ячейки (SHA-256) + CRC-16/XMODEM через `Buffer` |
 
 **Результат:** `npm install ton-wallet-finder` устанавливает **0 дополнительных пакетов**.
 Публичный API не изменился — при обновлении с v3 никаких правок в коде не требуется.
@@ -363,7 +417,7 @@ const result = await finder.findWalletWithEnding({ workers: 4 });
 |---|---|---|
 | Дефолт `showResult` | `true` | `false` |
 | `createWallet()` | `Promise<Address>` | `Address` (синхронно) |
-| `saveResultsToFile()` | `void` | `Promise<string \| undefined>` — путь к файлу |
+| `saveResultsToFile()` | `void` | v3: `Promise<void>`; 4.0.1+: `Promise<string \| undefined>` — путь к файлу |
 
 </details>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,3 +130,32 @@ export declare function saveResultsToFile(
     walletAddress: string,
     fileName?: string
 ): Promise<string | undefined>;
+
+/**
+ * Ed25519 key pair in tweetnacl layout: 32-byte public key and 64-byte secret key (seed ‖ publicKey).
+ */
+export interface Ed25519KeyPair {
+    readonly publicKey: Uint8Array;
+    readonly secretKey: Uint8Array;
+}
+
+/**
+ * Low-level primitives behind `TonWalletFinder`, exposed for testing and advanced use.
+ * Not yet covered by semver guarantees — signatures may change in a minor release.
+ */
+export declare const _internals: {
+    /** Generate a fresh 24-word TON mnemonic (passes the TON seed-version check). */
+    mnemonicNew(): Promise<string[]>;
+    /** Derive the Ed25519 key pair from a TON mnemonic (no password). */
+    mnemonicToPrivateKey(words: readonly string[]): Promise<Ed25519KeyPair>;
+    /** TON "basic seed" check — `true` if the mnemonic is valid without a password. */
+    isBasicSeed(words: readonly string[]): Promise<boolean>;
+    /** Bounceable, URL-safe WalletV4R2 address for a 32-byte public key. */
+    walletV4Address(publicKey: Uint8Array, workchain?: number): string;
+    /** TVM representation hash (SHA-256) of an ordinary cell. */
+    cellHash(bitsCount: number, bitsBytes: Uint8Array, refs: ReadonlyArray<{ depth: number; hash: Uint8Array }>): Uint8Array;
+    /** TVM bit padding: sets the completion bit after `bitsCount` data bits. */
+    padBits(bitsCount: number, bitsBytes: Uint8Array): Uint8Array;
+    /** CRC-16/XMODEM (poly 0x1021, init 0), as used in TON user-friendly addresses. */
+    crc16(data: Uint8Array): number;
+};

--- a/index.js
+++ b/index.js
@@ -118,14 +118,14 @@ function cellHash(bitsCount, bitsBytes, refs) {
 
     repr[cur++] = d1;
     repr[cur++] = d2;
-    bitsBytes.copy(repr, cur);  cur += dataLen;
+    repr.set(bitsBytes.subarray(0, dataLen), cur);  cur += dataLen;
 
     for (const r of refs) {
         repr[cur++] = (r.depth >> 8) & 0xff;
         repr[cur++] =  r.depth       & 0xff;
     }
     for (const r of refs) {
-        r.hash.copy(repr, cur);  cur += 32;
+        repr.set(r.hash, cur);  cur += 32;
     }
     return crypto.createHash('sha256').update(repr).digest();
 }
@@ -172,7 +172,7 @@ function walletV4Address(pubkey, workchain = 0) {
     const dataBuf = Buffer.alloc(41, 0);
     dataBuf.writeUInt32BE(0,           0);  // seqno
     dataBuf.writeUInt32BE(subwalletId, 4);  // subwallet_id
-    pubkey.copy(dataBuf, 8);                // 32 bytes public key
+    dataBuf.set(pubkey, 8);                 // 32 bytes public key
     const dataHash  = cellHash(321, padBits(321, dataBuf), []);
     const dataDepth = 0;
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "lint": "eslint index.js test/",
+    "lint": "eslint index.js worker.js test/",
     "test": "mocha --recursive"
   },
   "repository": {

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -63,6 +63,11 @@ describe('crypto primitives (reference vectors)', () => {
             expect(addr).to.equal(VECTOR.address);
         });
 
+        it('should accept a plain Uint8Array public key (not only Buffer)', () => {
+            const plain = new Uint8Array(Buffer.from(VECTOR.publicKey, 'hex'));
+            expect(walletV4Address(plain)).to.equal(VECTOR.address);
+        });
+
         it('should produce a 48-char base64url string with no padding', () => {
             const addr = walletV4Address(Buffer.alloc(32, 7));
             expect(addr).to.match(/^[A-Za-z0-9_-]{48}$/);


### PR DESCRIPTION
## Summary

Pre-release audit of the documentation against the 4.1.0 implementation, plus moving CI and the publish workflow off end-of-life Node.js. No behaviour change for callers.

### Documentation fixes (README EN/RU, index.d.ts, CONTRIBUTING, CHANGELOG)
- **Factual error:** the checksum was named CRC-16/CCITT; the code (and TON) use **CRC-16/XMODEM** (poly 0x1021, init 0). Fixed in both languages.
- `saveResultsToFile`, `createKeyPair`, `createWallet` and `_internals` were exported but undocumented in the README — now documented.
- Cancellation semantics (`err.name === 'AbortError'`, `err.cause === signal.reason`) and the 5-consecutive-failure limit documented.
- `targetEnding` 46-character limit added to the options table; ES-module example added to the Russian section.
- Migration table now distinguishes v3 (`Promise<void>`) from 4.0.1+ (`Promise<string | undefined>`) for `saveResultsToFile`.
- The security banner no longer claims the scanner "network access" flag comes from funding links (unverified); it lists the built-in modules actually imported instead.
- `index.d.ts` declares `_internals` — TypeScript consumers could not use it before.
- CONTRIBUTING lists all four test files and the real lint scope; chai pin stated exactly; LICENSE year updated.

### Node.js
- Node.js **20 reached end-of-life on 2026-04-30**; the publish workflow was still running on it. CI matrix is now `20.x, 22.x, 24.x, 26.x`; publish runs on **24.x** (Active LTS). `engines` stays `>=20` until the next major, and README/CONTRIBUTING say so.

### Code
- `walletV4Address` and `cellHash` use `TypedArray.set` instead of `Buffer.copy`, so any `Uint8Array` is accepted (matches the new typings). Reference-vector tests are unchanged and green; a test for a plain `Uint8Array` input added.
- `npm run lint` now covers `worker.js` (it was in the ESLint config but not in the script).

## Verification
- `npm run lint` clean; `npm test` 79 passing.
- Package installed from the local tarball into a separate project: `tsc --noEmit` passes for a consumer using `_internals`, `workers`, and `saveResultsToFile` under `moduleResolution: node16` and `bundler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CywtBeSyR8nr7akwyx5cUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CywtBeSyR8nr7akwyx5cUg)_