### PR TITLE
ci: publish via npm trusted publishing (OIDC) instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,13 @@
 name: Publish to npm
 
+# Publishes with npm Trusted Publishing (OIDC): no long-lived token, provenance
+# attached automatically. The package must have this repository + workflow file
+# registered as a trusted publisher on npmjs.com (see CONTRIBUTING.md).
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:   # manual re-run from the Actions tab if a tagged run failed
 
 jobs:
   test:
@@ -30,19 +34,27 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # for npm provenance
+      id-token: write  # OIDC token for npm trusted publishing + provenance
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 24.x
+          node-version: 24.x   # bundles npm >= 11.5.1, required for trusted publishing
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Check that the tag matches package.json
+        if: github.ref_type == 'tag'
+        run: |
+          PKG="v$(node -p "require('./package.json').version")"
+          if [ "$PKG" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json version $PKG"
+            exit 1
+          fi
 
       - run: npm ci
 
       - name: Publish
+        # No NODE_AUTH_TOKEN on purpose: npm authenticates through the OIDC token.
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `_internals` is declared in `index.d.ts`; `walletV4Address` and `cellHash` accept any
   `Uint8Array`, not only `Buffer`.
 - Release process documented in CONTRIBUTING (tag-driven publish, trusted publishing).
+- `publish.yml` switched to npm **trusted publishing** (OIDC): the `NPM_TOKEN` secret is
+  no longer used (npm now rejects direct publishing with tokens that bypass 2FA). The
+  workflow also verifies that the pushed tag matches `package.json` and can be started
+  manually (`workflow_dispatch`).
 
 ### Documentation
 - README: `saveResultsToFile`, `createKeyPair`, `createWallet` and `_internals` documented;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,13 +96,28 @@ Releases are published by CI only (`.github/workflows/publish.yml`), never from 
    ```sh
    git tag vX.Y.Z && git push origin vX.Y.Z
    ```
-3. The workflow runs lint + tests on Node.js 24, then `npm publish --provenance`.
+3. The workflow checks that the tag matches `package.json`, runs lint + tests on
+   Node.js 24, then `npm publish --provenance`.
 
-The workflow currently authenticates with the `NPM_TOKEN` repository secret. The
-recommended setup is npm **trusted publishing** (OIDC, no long-lived token): on
-npmjs.com open the package → Settings → Trusted publisher, and register
-`lendel/ton-wallet-finder` with workflow `publish.yml`. Once that is configured the
-`NODE_AUTH_TOKEN` line can be removed from `publish.yml` and the secret deleted.
+### Authentication: npm trusted publishing (OIDC)
+
+The workflow carries **no npm token**. npm authenticates the GitHub Actions run through
+its OIDC identity, and the provenance attestation is generated automatically. This has to
+be registered once on npmjs.com by a package maintainer:
+
+1. Open <https://www.npmjs.com/package/ton-wallet-finder/access> → **Trusted Publisher**
+   (also under the package's *Settings*).
+2. Choose **GitHub Actions** and enter:
+   - Organization or user: `lendel`
+   - Repository: `ton-wallet-finder`
+   - Workflow filename: `publish.yml`
+   - Environment: leave empty
+3. Delete the old `NPM_TOKEN` repository secret on GitHub — it is no longer used, and
+   npm is phasing out publishing with tokens that bypass 2FA.
+
+If a tagged run failed (for example before the trusted publisher was registered), fix the
+cause and either move the tag to the fixed commit and push it again, or start the
+workflow manually from the *Actions* tab (**Run workflow**) on `master`.
 
 ---
 


### PR DESCRIPTION
## Summary

The `v4.1.0` tagged run of `publish.yml` failed at `npm publish` with `E404 Not Found - PUT https://registry.npmjs.org/ton-wallet-finder`, *after* the provenance statement had already been signed and published to the Sigstore transparency log through the workflow's OIDC token. The registry returns 404 rather than 403 for an unauthorised publish, and the run log carried npm's notice that tokens which bypass 2FA are being restricted for direct publishing. In other words: the OIDC side works, the `NPM_TOKEN` secret is what the registry rejected.

### Changes
- **`publish.yml` uses npm trusted publishing.** `NODE_AUTH_TOKEN` is removed; npm 11.19 (bundled with Node 24) authenticates through the job's OIDC identity. Provenance stays on.
- **Tag/version guard:** a tagged run fails early if `vX.Y.Z` does not match `package.json`.
- **`workflow_dispatch`** so a failed tagged release can be re-run from the Actions tab on `master`.
- CONTRIBUTING: how to register the trusted publisher on npmjs.com and how to re-run a failed release. CHANGELOG entry under 4.1.0.

### Required one-time setup (maintainer only, cannot be done from CI)
On npmjs.com → package `ton-wallet-finder` → Settings → **Trusted Publisher** → GitHub Actions: user `lendel`, repository `ton-wallet-finder`, workflow `publish.yml`, environment empty. Then delete the `NPM_TOKEN` repository secret.

### Re-running the 4.1.0 release after merge
Either move the tag to the fixed commit (`git push origin :refs/tags/v4.1.0`, retag `master`, push), or use **Run workflow** on `master` in the Actions tab. The package contents are identical either way (the workflow file is not part of the tarball).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CywtBeSyR8nr7akwyx5cUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01CywtBeSyR8nr7akwyx5cUg)_