### PR TITLE
5.0.0: options-object constructor, workers moved to constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.0.0] — 2026-09-06
+
+### Breaking Changes
+- **Options-object constructor.** `TonWalletFinder(targetEnding, showProcess, showResult,
+  saveResult)` is replaced by `TonWalletFinder(targetEnding, { showProcess, showResult,
+  saveResult, workers, walletVersion })`. No positional-argument fallback — see the migration
+  table below.
+- **`workers` moved to the constructor.** It was a `findWalletWithEnding()`-only option since
+  4.1.0; it is now also a constructor option that sets the default for every call on that
+  instance. `findWalletWithEnding({ workers })` still accepts `workers` as a per-call override
+  of the constructor default, exactly as `signal` already worked.
+
+### Added
+- `walletVersion` constructor option. Only `'v4r2'` (the existing, and now default, behaviour)
+  is accepted for now — anything else throws at construction time. This reserves the option
+  name and default so that adding `'v3r2'` / `'v5r1'` support later is an additive (minor)
+  change, not another breaking one.
+- `index.d.ts`: `TonWalletFinderOptions` interface and `WalletVersion` type; `workers` and
+  `walletVersion` added as readonly instance properties on `TonWalletFinder`.
+
+### Migration checklist
+
+| v4.x position | v5.0.0 key |
+|---|---|
+| `new TonWalletFinder(targetEnding, showProcess, showResult, saveResult)` | `new TonWalletFinder(targetEnding, { showProcess, showResult, saveResult })` |
+| `findWalletWithEnding({ workers })` (per-call only) | `new TonWalletFinder(targetEnding, { workers })` (default) or `findWalletWithEnding({ workers })` (per-call override, unchanged) |
+| *(none)* | `walletVersion` — new, defaults to `'v4r2'` (only supported value for now) |
+
+```js
+// v4.x
+new TonWalletFinder('abc', false, true, false);
+
+// v5.0.0
+new TonWalletFinder('abc', { showResult: true });
+```
+
+---
+
 ## [4.1.0] — 2026-09-06
 
 ### Added

--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,9 @@ Find a wallet whose address ends with any string you choose.
 - [Options](#options)
 - [API](#api)
 - [Performance](#performance)
+- [What's new in v5](#-whats-new-in-v5)
 - [What's new in v4](#-whats-new-in-v4)
+- [Migration from v4](#-migration-from-v4)
 - [Migration from v2/v3](#-migration-from-v2v3)
 - [Support the Author](#-support-the-author)
 - [License](#license)
@@ -81,12 +83,24 @@ node findWallet.js
 
 ## Options
 
+```javascript
+new TonWalletFinder(targetEnding, {
+  showProcess,   // boolean
+  showResult,    // boolean
+  saveResult,    // boolean
+  workers,       // number | 'auto'
+  walletVersion, // 'v4r2'
+});
+```
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `targetEnding` | `string` | required | Desired address ending. Latin letters, digits, `-`, `_`, at most 46 characters. **Case-sensitive.** |
-| `showProcess` | `boolean` | `false` | Log each attempted address to console |
-| `showResult` | `boolean` | `false` | Log found wallet details to console. **Keep `false` in shared/logged environments to avoid exposing private keys.** |
-| `saveResult` | `boolean` | `false` | Save result to `ton_wallet_results.txt` in the current working directory. Never overwrites: an existing file gets a `-2`, `-3`, … suffix |
+| `options.showProcess` | `boolean` | `false` | Log each attempted address to console |
+| `options.showResult` | `boolean` | `false` | Log found wallet details to console. **Keep `false` in shared/logged environments to avoid exposing private keys.** |
+| `options.saveResult` | `boolean` | `false` | Save result to `ton_wallet_results.txt` in the current working directory. Never overwrites: an existing file gets a `-2`, `-3`, … suffix |
+| `options.workers` | `number \| 'auto'` | `1` | Default worker-thread count for `findWalletWithEnding()` (see [Performance](#performance)). Overridable per call. |
+| `options.walletVersion` | `'v4r2'` | `'v4r2'` | TON wallet contract version to derive the address for. Only `'v4r2'` is supported today; different versions produce different addresses from the same mnemonic, so this must match whatever wallet software you'll import the mnemonic into. |
 
 ---
 
@@ -132,7 +146,9 @@ const result = await finder.findWalletWithEnding({ workers: 'auto' });
 const result = await finder.findWalletWithEnding({ workers: 4 });
 ```
 
-`workers` defaults to `1` (single-threaded, same behaviour as before). It can be combined with `signal`.
+`workers` defaults to whatever was passed to the constructor (itself `1` by default, i.e.
+single-threaded). Passing `workers` to `findWalletWithEnding()` overrides that default for this
+call only. It can be combined with `signal`.
 
 ### `saveResultsToFile(publicKey, privateKey, words, walletAddress, [fileName]) → Promise<string | undefined>`
 
@@ -179,6 +195,28 @@ count is geometrically distributed), so treat these as medians, not guarantees.
 
 ---
 
+## 🚀 What's new in v5
+
+Version 5.0.0 replaces the four positional constructor arguments with a single options
+object, and moves `workers` from a `findWalletWithEnding()`-only option to a constructor
+default (still overridable per call):
+
+```javascript
+// v4.x
+new TonWalletFinder('abc', false, true, false);
+
+// v5.0.0
+new TonWalletFinder('abc', { showResult: true });
+```
+
+It also adds a `walletVersion` option, reserved for upcoming `'v3r2'`/`'v5r1'` support.
+Today only `'v4r2'` (the existing default behaviour) is accepted — passing anything else
+throws at construction time.
+
+See [Migration from v4](#-migration-from-v4) below for the full breaking-change table.
+
+---
+
 ## 🚀 What's new in v4
 
 Version 4.0.0 completely eliminates all production dependencies.
@@ -196,6 +234,45 @@ Starting with v4, everything is implemented using **Node.js built-in modules onl
 
 **Result:** `npm install ton-wallet-finder` now installs **0 additional packages**.
 The public API is identical — no code changes required when upgrading from v3.
+
+---
+
+## 🔀 Migration from v4
+
+### v4 → v5.0.0 breaking changes
+
+| What changed | v4.x behaviour | v5.0.0 behaviour |
+|---|---|---|
+| Constructor signature | `TonWalletFinder(targetEnding, showProcess, showResult, saveResult)` | `TonWalletFinder(targetEnding, { showProcess, showResult, saveResult, workers, walletVersion })` |
+| `workers` | `findWalletWithEnding({ workers })` only, default `1` | Also a constructor option (sets the default); `findWalletWithEnding({ workers })` still overrides it per call |
+| `walletVersion` | did not exist | New option, default `'v4r2'` (only supported value for now) |
+
+### Migration checklist
+
+1. **Constructor call** — move the three trailing booleans into an options object:
+   ```js
+   // v4.x
+   new TonWalletFinder('abc', true, true, false);
+   // v5.0.0
+   new TonWalletFinder('abc', { showProcess: true, showResult: true });
+   ```
+
+2. **`workers`** — if you always passed the same `workers` value to every
+   `findWalletWithEnding()` call, move it to the constructor instead:
+   ```js
+   // v4.x
+   const finder = new TonWalletFinder('abc');
+   await finder.findWalletWithEnding({ workers: 'auto' });
+   // v5.0.0
+   const finder = new TonWalletFinder('abc', { workers: 'auto' });
+   await finder.findWalletWithEnding();
+   ```
+   No change needed if you want to keep passing `workers` per call — it still works as a
+   per-call override.
+
+3. **`walletVersion`** — nothing to do; it defaults to `'v4r2'`, which is what v4.x always
+   produced. It exists now only so it can be validated; `'v3r2'`/`'v5r1'` are not implemented
+   yet.
 
 ---
 
@@ -303,12 +380,24 @@ import { TonWalletFinder } from 'ton-wallet-finder';
 
 ### Опции
 
+```javascript
+new TonWalletFinder(targetEnding, {
+  showProcess,   // boolean
+  showResult,    // boolean
+  saveResult,    // boolean
+  workers,       // number | 'auto'
+  walletVersion, // 'v4r2'
+});
+```
+
 | Параметр | Тип | По умолчанию | Описание |
 |----------|-----|--------------|----------|
 | `targetEnding` | `string` | обязательный | Желаемое окончание адреса. Латиница, цифры, `-`, `_`, не более 46 символов. **Регистрозависимо.** |
-| `showProcess` | `boolean` | `false` | Выводить каждый проверяемый адрес в консоль |
-| `showResult` | `boolean` | `false` | Вывести найденный кошелёк в консоль. **Оставьте `false` в окружениях с логированием, чтобы не раскрывать приватный ключ.** |
-| `saveResult` | `boolean` | `false` | Сохранить результат в `ton_wallet_results.txt` в текущей рабочей директории. Существующий файл не перезаписывается: добавляется суффикс `-2`, `-3`, … |
+| `options.showProcess` | `boolean` | `false` | Выводить каждый проверяемый адрес в консоль |
+| `options.showResult` | `boolean` | `false` | Вывести найденный кошелёк в консоль. **Оставьте `false` в окружениях с логированием, чтобы не раскрывать приватный ключ.** |
+| `options.saveResult` | `boolean` | `false` | Сохранить результат в `ton_wallet_results.txt` в текущей рабочей директории. Существующий файл не перезаписывается: добавляется суффикс `-2`, `-3`, … |
+| `options.workers` | `number \| 'auto'` | `1` | Значение по умолчанию для числа воркеров в `findWalletWithEnding()` (см. [Производительность](#производительность)). Можно переопределить при вызове. |
+| `options.walletVersion` | `'v4r2'` | `'v4r2'` | Версия контракта TON-кошелька для деривации адреса. Пока поддерживается только `'v4r2'`; разные версии дают разные адреса из одной и той же мнемоники, поэтому значение должно совпадать с тем кошельком, в который вы будете импортировать мнемонику. |
 
 ### API
 
@@ -352,7 +441,9 @@ const result = await finder.findWalletWithEnding({ workers: 'auto' });
 const result = await finder.findWalletWithEnding({ workers: 4 });
 ```
 
-По умолчанию `workers: 1` (один поток, прежнее поведение). Сочетается с `signal`.
+По умолчанию используется значение, переданное в конструктор (само по умолчанию — `1`,
+то есть один поток). `workers`, переданный в `findWalletWithEnding()`, переопределяет это
+значение только для данного вызова. Сочетается с `signal`.
 
 #### `saveResultsToFile(publicKey, privateKey, words, walletAddress, [fileName]) → Promise<string | undefined>`
 
@@ -393,6 +484,26 @@ const result = await finder.findWalletWithEnding({ workers: 4 });
 Оценка: `время ≈ 64ⁿ / (5 × ядра)` секунд. Разброс между запусками большой (число попыток
 распределено геометрически), поэтому это медианы, а не гарантии.
 
+### Что нового в v5
+
+В версии 5.0.0 четыре позиционных аргумента конструктора заменены единым объектом опций,
+а `workers` стал значением по умолчанию, задаваемым в конструкторе (по-прежнему можно
+переопределить при вызове):
+
+```javascript
+// v4.x
+new TonWalletFinder('abc', false, true, false);
+
+// v5.0.0
+new TonWalletFinder('abc', { showResult: true });
+```
+
+Также добавлена опция `walletVersion`, зарезервированная под будущую поддержку
+`'v3r2'`/`'v5r1'`. Пока принимается только `'v4r2'` (нынешнее поведение по умолчанию) —
+любое другое значение вызывает исключение при создании экземпляра.
+
+Полную таблицу breaking-изменений см. в разделе [Миграция с v4](#миграция-с-v4) ниже.
+
 ### Что нового в v4
 
 В версии 4.0.0 полностью отказались от избыточных внешних зависимостей.
@@ -410,6 +521,43 @@ const result = await finder.findWalletWithEnding({ workers: 4 });
 
 **Результат:** `npm install ton-wallet-finder` устанавливает **0 дополнительных пакетов**.
 Публичный API не изменился — при обновлении с v3 никаких правок в коде не требуется.
+
+### Миграция с v4
+
+#### Breaking-изменения v4 → v5.0.0
+
+| Что изменилось | Поведение v4.x | Поведение v5.0.0 |
+|---|---|---|
+| Сигнатура конструктора | `TonWalletFinder(targetEnding, showProcess, showResult, saveResult)` | `TonWalletFinder(targetEnding, { showProcess, showResult, saveResult, workers, walletVersion })` |
+| `workers` | только в `findWalletWithEnding({ workers })`, по умолчанию `1` | Также опция конструктора (задаёт значение по умолчанию); `findWalletWithEnding({ workers })` по-прежнему переопределяет его для конкретного вызова |
+| `walletVersion` | не существовала | Новая опция, по умолчанию `'v4r2'` (пока единственное поддерживаемое значение) |
+
+#### Чек-лист миграции
+
+1. **Вызов конструктора** — перенесите три последних булевых аргумента в объект опций:
+   ```js
+   // v4.x
+   new TonWalletFinder('abc', true, true, false);
+   // v5.0.0
+   new TonWalletFinder('abc', { showProcess: true, showResult: true });
+   ```
+
+2. **`workers`** — если вы всегда передавали одно и то же значение `workers` в каждый
+   вызов `findWalletWithEnding()`, перенесите его в конструктор:
+   ```js
+   // v4.x
+   const finder = new TonWalletFinder('abc');
+   await finder.findWalletWithEnding({ workers: 'auto' });
+   // v5.0.0
+   const finder = new TonWalletFinder('abc', { workers: 'auto' });
+   await finder.findWalletWithEnding();
+   ```
+   Если вы хотите по-прежнему передавать `workers` при каждом вызове — ничего менять не
+   нужно, это по-прежнему работает как переопределение для конкретного вызова.
+
+3. **`walletVersion`** — ничего делать не нужно; по умолчанию `'v4r2'`, то есть ровно то,
+   что v4.x всегда и производила. Опция появилась сейчас только для того, чтобы её можно
+   было валидировать; `'v3r2'`/`'v5r1'` пока не реализованы.
 
 ### Миграция с v2/v3
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,40 @@ export interface WalletResult {
 }
 
 /**
+ * TON wallet contract version to derive the address for.
+ * Currently only `'v4r2'` is implemented; other values are reserved for future releases.
+ */
+export type WalletVersion = 'v4r2';
+
+/**
+ * Options accepted by the `TonWalletFinder` constructor.
+ */
+export interface TonWalletFinderOptions {
+    /** Log each attempted address to console. Default: `false` */
+    readonly showProcess?: boolean;
+
+    /** Log the found wallet credentials to console. Default: `false` */
+    readonly showResult?: boolean;
+
+    /** Save the found wallet credentials to a text file. Default: `false` */
+    readonly saveResult?: boolean;
+
+    /**
+     * Default number of worker threads to search on in parallel, or `'auto'` for one per
+     * available CPU core. Default: `1` (single-threaded, on the main thread).
+     * Overridable per call via `findWalletWithEnding({ workers })`.
+     */
+    readonly workers?: number | 'auto';
+
+    /**
+     * TON wallet contract version to derive the address for. Default: `'v4r2'`.
+     * Different versions produce different addresses from the same mnemonic, so this
+     * must match whatever wallet software the mnemonic will actually be imported into.
+     */
+    readonly walletVersion?: WalletVersion;
+}
+
+/**
  * Options accepted by `findWalletWithEnding`.
  */
 export interface FindOptions {
@@ -26,7 +60,7 @@ export interface FindOptions {
 
     /**
      * Number of worker threads to search on in parallel, or `'auto'` for one per
-     * available CPU core. Default: `1` (single-threaded, on the main thread).
+     * available CPU core. Overrides the constructor's `workers` option for this call only.
      * Throughput scales almost linearly with the number of cores.
      */
     readonly workers?: number | 'auto';
@@ -64,21 +98,23 @@ export declare class TonWalletFinder {
     readonly showResult: boolean;
     /** Whether to save the found wallet credentials to a file */
     readonly saveResult: boolean;
+    /** Default worker count used by `findWalletWithEnding()` unless overridden per call */
+    readonly workers: number | 'auto';
+    /** TON wallet contract version addresses are derived for */
+    readonly walletVersion: WalletVersion;
 
     /**
      * @param targetEnding - Desired suffix for the wallet address.
      *   Only Latin letters [a-zA-Z], digits [0-9], dashes [-] and underscores [_] are allowed.
      *   At most 46 characters (a TON address has 46 matchable characters after the `EQ`/`UQ` tag).
-     * @param showProcess - Log each attempted address. Default: `false`
-     * @param showResult  - Log the found wallet to console. Default: `false`
-     * @param saveResult  - Save the result to a text file. Default: `false`
-     * @throws {Error} If `targetEnding` contains invalid characters or is longer than 46 characters.
+     * @param options - Optional configuration.
+     * @throws {Error} If `targetEnding` contains invalid characters or is longer than 46
+     *   characters, or if `walletVersion` is not a supported version.
+     * @throws {RangeError} If `workers` is not a positive integer or `'auto'`.
      */
     constructor(
         targetEnding: string,
-        showProcess?: boolean,
-        showResult?: boolean,
-        saveResult?: boolean
+        options?: TonWalletFinderOptions
     );
 
     /**

--- a/index.js
+++ b/index.js
@@ -209,15 +209,24 @@ const MAX_TARGET_LENGTH = 46;
 // Transient errors are retried; a persistent one must not spin forever.
 const MAX_CONSECUTIVE_ERRORS = 5;
 
+// Only wallet version implemented so far; validated eagerly so a typo fails at
+// construction time instead of producing an address for the wrong wallet.
+const SUPPORTED_WALLET_VERSIONS = ['v4r2'];
+
 class TonWalletFinder {
     /**
      * @param {string}  targetEnding  - Desired address ending (Latin letters, digits, `-`, `_`).
      *                                  The match is case-sensitive (base64url alphabet).
-     * @param {boolean} [showProcess=false] - Log each attempted address to console
-     * @param {boolean} [showResult=false]  - Log found wallet details to console
-     * @param {boolean} [saveResult=false]  - Save result to ton_wallet_results.txt
+     * @param {object}  [options={}]                 - Optional configuration.
+     * @param {boolean} [options.showProcess=false]  - Log each attempted address to console
+     * @param {boolean} [options.showResult=false]   - Log found wallet details to console
+     * @param {boolean} [options.saveResult=false]   - Save result to ton_wallet_results.txt
+     * @param {number|'auto'} [options.workers=1]    - Default worker count for `findWalletWithEnding()`;
+     *        overridable per call. See `findWalletWithEnding` for the accepted values.
+     * @param {'v4r2'} [options.walletVersion='v4r2'] - TON wallet contract version to derive
+     *        the address for. Currently only `'v4r2'` is supported.
      */
-    constructor(targetEnding, showProcess = false, showResult = false, saveResult = false) {
+    constructor(targetEnding, options = {}) {
         // Dash at end of character class avoids ambiguous range
         const validEndingRegex = /^[a-zA-Z0-9_-]+$/;
         if (!validEndingRegex.test(targetEnding)) {
@@ -227,10 +236,29 @@ class TonWalletFinder {
             throw new Error(`Invalid target ending. A TON address has only ${MAX_TARGET_LENGTH} matchable characters, so an ending of ${targetEnding.length} characters can never be found.`);
         }
 
-        this.targetEnding = targetEnding;
-        this.showProcess  = showProcess;
-        this.showResult   = showResult;
-        this.saveResult   = saveResult;
+        // Safe destructure — works correctly for both undefined and null
+        const {
+            showProcess = false,
+            showResult = false,
+            saveResult = false,
+            workers = 1,
+            walletVersion = 'v4r2',
+        } = options !== null ? options : {};
+
+        if (!SUPPORTED_WALLET_VERSIONS.includes(walletVersion)) {
+            throw new Error(`Invalid walletVersion: expected one of ${SUPPORTED_WALLET_VERSIONS.map(v => `'${v}'`).join(', ')}, got ${JSON.stringify(walletVersion)}.`);
+        }
+        // Validate eagerly so a bad default fails at construction, not on first search.
+        // 'auto' is deliberately not resolved here — resolveWorkerCount() re-evaluates it
+        // per search so a later change in available CPUs is picked up.
+        resolveWorkerCount(workers);
+
+        this.targetEnding  = targetEnding;
+        this.showProcess   = showProcess;
+        this.showResult    = showResult;
+        this.saveResult    = saveResult;
+        this.workers       = workers;
+        this.walletVersion = walletVersion;
     }
 
     // Generate a new 24-word mnemonic and derive an Ed25519 key pair from it
@@ -254,14 +282,14 @@ class TonWalletFinder {
      *
      * @param {object}      [options={}]     - Optional configuration.
      * @param {AbortSignal} [options.signal]  - Optional AbortSignal to cancel the search.
-     * @param {number|'auto'} [options.workers=1] - Number of worker threads to search in
-     *        parallel. `'auto'` uses every available CPU core. `1` (default) searches on the
-     *        main thread exactly as before.
+     * @param {number|'auto'} [options.workers=this.workers] - Number of worker threads to
+     *        search in parallel, overriding the constructor's `workers` option for this call
+     *        only. `'auto'` uses every available CPU core. `1` searches on the main thread.
      * @returns {Promise<{ publicKey: string, privateKey: string, words: string[], walletAddress: string }>}
      */
     async findWalletWithEnding(options = {}) {
         // Safe destructure — works correctly for both undefined and null
-        const { signal, workers = 1 } = options !== null ? options : {};
+        const { signal, workers = this.workers } = options !== null ? options : {};
 
         const workerCount = resolveWorkerCount(workers);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ton-wallet-finder",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ton-wallet-finder",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "funding": [
         {
           "type": "cryptocurrency",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ton-wallet-finder",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Vanity address generator for TON blockchain — find a WalletV4 address ending with any custom string.",
   "main": "index.js",
   "exports": {

--- a/test/TonWalletFinder.test.js
+++ b/test/TonWalletFinder.test.js
@@ -61,6 +61,56 @@ describe('TonWalletFinder', () => {
             const finder = new TonWalletFinder('x');
             expect(finder.saveResult).to.equal(false);
         });
+
+        it('should default workers to 1', () => {
+            const finder = new TonWalletFinder('x');
+            expect(finder.workers).to.equal(1);
+        });
+
+        it('should default walletVersion to v4r2', () => {
+            const finder = new TonWalletFinder('x');
+            expect(finder.walletVersion).to.equal('v4r2');
+        });
+
+        it('should accept an options object and expose the values as instance properties', () => {
+            const finder = new TonWalletFinder('x', {
+                showProcess: true,
+                showResult: true,
+                saveResult: true,
+                workers: 4,
+                walletVersion: 'v4r2',
+            });
+            expect(finder.showProcess).to.equal(true);
+            expect(finder.showResult).to.equal(true);
+            expect(finder.saveResult).to.equal(true);
+            expect(finder.workers).to.equal(4);
+            expect(finder.walletVersion).to.equal('v4r2');
+        });
+
+        it('should work correctly when null is passed as options', () => {
+            expect(() => new TonWalletFinder('x', null)).not.to.throw();
+            const finder = new TonWalletFinder('x', null);
+            expect(finder.showProcess).to.equal(false);
+            expect(finder.workers).to.equal(1);
+            expect(finder.walletVersion).to.equal('v4r2');
+        });
+
+        it('should throw a RangeError on an invalid workers option', () => {
+            expect(() => new TonWalletFinder('x', { workers: 0 })).to.throw(RangeError);
+            expect(() => new TonWalletFinder('x', { workers: -1 })).to.throw(RangeError);
+            expect(() => new TonWalletFinder('x', { workers: 1.5 })).to.throw(RangeError);
+        });
+
+        it("should accept workers: 'auto' without resolving it at construction time", () => {
+            const finder = new TonWalletFinder('x', { workers: 'auto' });
+            expect(finder.workers).to.equal('auto');
+        });
+
+        it('should throw on an unsupported walletVersion', () => {
+            expect(() => new TonWalletFinder('x', { walletVersion: 'v3r2' })).to.throw(Error, /walletVersion/);
+            expect(() => new TonWalletFinder('x', { walletVersion: 'v5r1' })).to.throw(Error, /walletVersion/);
+            expect(() => new TonWalletFinder('x', { walletVersion: 'bogus' })).to.throw(Error, /walletVersion/);
+        });
     });
 
     // -------------------------------------------------------------------------
@@ -125,7 +175,7 @@ describe('TonWalletFinder', () => {
             // Single character: ~1/64 chance per attempt → fast in practice
             this.timeout(60000);
             const target = 'A';
-            const finder = new TonWalletFinder(target, false, false, false);
+            const finder = new TonWalletFinder(target);
             const result = await finder.findWalletWithEnding();
             expect(result).to.have.all.keys('publicKey', 'privateKey', 'words', 'walletAddress');
             expect(result.walletAddress).to.be.a('string');
@@ -138,7 +188,7 @@ describe('TonWalletFinder', () => {
         // null argument must not throw TypeError
         it('should work correctly when null is passed as options', async function () {
             this.timeout(60000);
-            const finder = new TonWalletFinder('A', false, false, false);
+            const finder = new TonWalletFinder('A');
             let result;
             try {
                 result = await finder.findWalletWithEnding(null);
@@ -150,7 +200,7 @@ describe('TonWalletFinder', () => {
 
         it('should produce no console.log output when showResult and showProcess are both false', async function () {
             this.timeout(60000);
-            const finder = new TonWalletFinder('A', false, false, false);
+            const finder = new TonWalletFinder('A');
 
             // Stub crypto helpers so the test is deterministic and doesn't hang when
             // console.log is replaced (some WASM-backed crypto libs bind console.log
@@ -177,7 +227,7 @@ describe('TonWalletFinder', () => {
             this.timeout(60000);
             const writeFileStub = sinon.stub(fs.promises, 'writeFile').resolves();
             try {
-                const finder = new TonWalletFinder('A', false, false, true);
+                const finder = new TonWalletFinder('A', { saveResult: true });
                 await finder.findWalletWithEnding();
                 expect(writeFileStub.calledOnce).to.equal(true);
                 const writtenData = writeFileStub.firstCall.args[1];
@@ -193,7 +243,7 @@ describe('TonWalletFinder', () => {
         // AbortSignal cancellation
         it('should reject with an Error when AbortSignal is triggered', async function () {
             this.timeout(5000);
-            const finder = new TonWalletFinder('AAAAAAAAAA', false, false, false);
+            const finder = new TonWalletFinder('AAAAAAAAAA');
             const controller = new AbortController();
             const timer = setTimeout(() => controller.abort('Search cancelled by test'), 100);
             let caughtError;
@@ -215,7 +265,7 @@ describe('TonWalletFinder', () => {
             const controller = new AbortController();
             const reason = new Error('timeout hit');
             controller.abort(reason);
-            const finder = new TonWalletFinder('A', false, false, false);
+            const finder = new TonWalletFinder('A');
             let caughtError;
             try {
                 await finder.findWalletWithEnding({ signal: controller.signal });
@@ -231,7 +281,7 @@ describe('TonWalletFinder', () => {
             this.timeout(5000);
             const controller = new AbortController();
             controller.abort('Pre-aborted');
-            const finder = new TonWalletFinder('A', false, false, false);
+            const finder = new TonWalletFinder('A');
             let caughtError;
             try {
                 await finder.findWalletWithEnding({ signal: controller.signal });
@@ -247,7 +297,7 @@ describe('TonWalletFinder', () => {
             this.timeout(60000);
             const logStub = sinon.stub(console, 'log');
             try {
-                const finder = new TonWalletFinder('A', true, false, false);
+                const finder = new TonWalletFinder('A', { showProcess: true });
                 await finder.findWalletWithEnding();
                 const tryingCalls = logStub.getCalls().filter(c => c.args[0] === 'Trying address:');
                 expect(tryingCalls.length).to.be.at.least(1);
@@ -259,7 +309,7 @@ describe('TonWalletFinder', () => {
         // Error path: createKeyPair throws on first call, should recover and continue
         it('should continue searching after a transient key generation error', async function () {
             this.timeout(60000);
-            const finder = new TonWalletFinder('A', false, false, false);
+            const finder = new TonWalletFinder('A');
             let callCount = 0;
             const original = finder.createKeyPair.bind(finder);
             const stub = sinon.stub(finder, 'createKeyPair').callsFake(async () => {
@@ -280,7 +330,7 @@ describe('TonWalletFinder', () => {
         // Persistent error: must NOT spin forever
         it('should reject after repeated consecutive key generation errors', async function () {
             this.timeout(5000);
-            const finder = new TonWalletFinder('A', false, false, false);
+            const finder = new TonWalletFinder('A');
             const boom = new Error('crypto unavailable');
             const stub = sinon.stub(finder, 'createKeyPair').rejects(boom);
             const errorStub = sinon.stub(console, 'error');
@@ -301,7 +351,7 @@ describe('TonWalletFinder', () => {
 
         it('should reset the consecutive error counter after a successful attempt', async function () {
             this.timeout(5000);
-            const finder = new TonWalletFinder('A', false, false, false);
+            const finder = new TonWalletFinder('A');
             const fakeKeyPair = { publicKey: Buffer.alloc(32), secretKey: Buffer.alloc(64) };
             let call = 0;
             // Pattern: 4 errors, 1 success (no match), 4 errors, 1 success (match).

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -50,6 +50,44 @@ describe('findWalletWithEnding({ workers })', () => {
         });
     });
 
+    describe('constructor default', () => {
+        it('should use the constructor workers option when no per-call override is given', async () => {
+            const finder = new TonWalletFinder('A', { workers: 3 });
+            const spawned = [];
+            sinon.stub(finder, '_createWorker').callsFake(workerData => {
+                const w = fakeWorker();
+                w.workerData = workerData;
+                spawned.push(w);
+                return w;
+            });
+            try {
+                const p = finder.findWalletWithEnding();
+                expect(spawned).to.have.lengthOf(3);
+                spawned[0].emit('message', {
+                    type: 'found', publicKey: new Uint8Array(32), secretKey: new Uint8Array(64),
+                    words: [], address: 'EQA',
+                });
+                await p;
+            } finally {
+                sinon.restore();
+            }
+        });
+
+        it('should let a per-call workers option override the constructor default', async () => {
+            const finder = new TonWalletFinder('A', { workers: 3 });
+            const spawn = sinon.stub(finder, '_createWorker');
+            sinon.stub(finder, 'createKeyPair')
+                .resolves({ keyPair: { publicKey: Buffer.alloc(32), secretKey: Buffer.alloc(64) }, words: Array(24).fill('abandon') });
+            sinon.stub(finder, 'createWallet').returns({ toString: () => 'EQ' + 'A'.repeat(46) });
+            try {
+                await finder.findWalletWithEnding({ workers: 1 });
+                expect(spawn.callCount).to.equal(0);
+            } finally {
+                sinon.restore();
+            }
+        });
+    });
+
     describe('with fake workers (deterministic)', () => {
         let finder;
         let spawned;


### PR DESCRIPTION
## Summary

First step of the [v5.0.0 roadmap](ROADMAP.md): the options-object constructor, split out from wallet-version selection so each breaking change ships in its own PR/major bump.

- `TonWalletFinder(targetEnding, showProcess, showResult, saveResult)` → `TonWalletFinder(targetEnding, { showProcess, showResult, saveResult, workers, walletVersion })`. Clean break, no positional-argument fallback.
- `workers` moves from a `findWalletWithEnding()`-only option (4.1.0) to a constructor default. `findWalletWithEnding({ workers })` still overrides it per call, exactly like `signal` already works.
- New `walletVersion` option, validated against the single currently-supported value `'v4r2'` — anything else throws at construction time. This reserves the option so that adding `'v3r2'`/`'v5r1'` support later (tracked in the roadmap) is an additive minor change, not another major bump.
- `index.d.ts`, README (English + Russian), and `CHANGELOG.md` updated, including a v4→v5 migration table in the same format as the existing v2/v3→v4 one.
- `package.json` bumped to `5.0.0`.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (88 tests), including new coverage for: options-object defaults, `null` options, invalid `workers` (`RangeError`), invalid `walletVersion` (throws), constructor `workers` default flowing into `findWalletWithEnding()`, and per-call `workers` override still winning
- [x] All existing test call sites updated to the new constructor signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUr81eUXLhV8VCwKnHEt5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUr81eUXLhV8VCwKnHEt5w)_