### PR TITLE
5.1.0: wallet version selection (v3r2 / v4r2 / v5r1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.1.0] — 2026-09-06
+
+### Added
+- **Wallet version selection.** `walletVersion` now accepts `'v3r2'` and `'v5r1'` in addition
+  to `'v4r2'` (still the default, so existing callers get exactly the same addresses as before).
+  Different versions derive different addresses from the same mnemonic — pick the one matching
+  the wallet software the mnemonic will be imported into.
+  - `'v3r2'`: WalletV3R2 — data cell `seqno | subwallet_id | pubkey` (320 bits).
+  - `'v5r1'`: WalletV5R1 (W5) — data cell `is_signature_allowed | seqno | wallet_id | pubkey |
+    extensions` (322 bits); `wallet_id` is the mainnet client context (workchain 0, subwallet 0)
+    XOR'ed with the network global id `-239`, as in `@ton/ton`.
+- Worker threads receive `walletVersion` and derive the same address as the main thread.
+- `_internals.walletAddress(version, publicKey)`, `_internals.walletV3R2Address`,
+  `_internals.walletV5R1Address`.
+- `test/crypto.test.js`: reference addresses for V3R2 and V5R1 for the existing reference
+  mnemonic, produced with `@ton/ton` 16.3 (`WalletContractV3R2` / `WalletContractV5R1`,
+  installed in a scratch directory — still not a project dependency). The code-cell hash and
+  depth constants come from the same run.
+
+### Changed
+- `index.d.ts`: `WalletVersion` is `'v3r2' | 'v4r2' | 'v5r1'`.
+- Address derivation refactored around a shared `StateInit` hashing helper; `walletV4Address`
+  behaviour is unchanged (same reference vector).
+
+---
+
 ## [5.0.0] — 2026-09-06
 
 ### Breaking Changes

--- a/Readme.md
+++ b/Readme.md
@@ -89,7 +89,7 @@ new TonWalletFinder(targetEnding, {
   showResult,    // boolean
   saveResult,    // boolean
   workers,       // number | 'auto'
-  walletVersion, // 'v4r2'
+  walletVersion, // 'v3r2' | 'v4r2' | 'v5r1'
 });
 ```
 
@@ -100,7 +100,24 @@ new TonWalletFinder(targetEnding, {
 | `options.showResult` | `boolean` | `false` | Log found wallet details to console. **Keep `false` in shared/logged environments to avoid exposing private keys.** |
 | `options.saveResult` | `boolean` | `false` | Save result to `ton_wallet_results.txt` in the current working directory. Never overwrites: an existing file gets a `-2`, `-3`, … suffix |
 | `options.workers` | `number \| 'auto'` | `1` | Default worker-thread count for `findWalletWithEnding()` (see [Performance](#performance)). Overridable per call. |
-| `options.walletVersion` | `'v4r2'` | `'v4r2'` | TON wallet contract version to derive the address for. Only `'v4r2'` is supported today; different versions produce different addresses from the same mnemonic, so this must match whatever wallet software you'll import the mnemonic into. |
+| `options.walletVersion` | `'v3r2' \| 'v4r2' \| 'v5r1'` | `'v4r2'` | TON wallet contract version to derive the address for — see [Wallet versions](#wallet-versions). |
+
+### Wallet versions
+
+| `walletVersion` | Contract | Notes |
+|---|---|---|
+| `'v3r2'` | WalletV3R2 | Legacy contract, still importable in most wallets |
+| `'v4r2'` | WalletV4R2 | **Default.** Same addresses as every previous release |
+| `'v5r1'` | WalletV5R1 (W5) | Current default in Tonkeeper / MyTonWallet and others. Mainnet wallet id, subwallet 0 |
+
+> **The same mnemonic gives a different address for every version.** The vanity address you
+> find only exists for the version you searched with, so `walletVersion` must match the
+> wallet software you will import the 24 words into (and the version selected there). If you
+> are unsure, check which address format your wallet shows for an existing seed phrase.
+
+```javascript
+const finder = new TonWalletFinder('abc', { walletVersion: 'v5r1' });
+```
 
 ---
 
@@ -164,10 +181,11 @@ path of the written file, or `undefined` if writing failed (the error is logged,
 - `finder.createKeyPair()` → `Promise<{ keyPair: { publicKey, secretKey }, words }>` — a fresh
   24-word TON mnemonic and its Ed25519 key pair.
 - `finder.createWallet(keyPair)` → object whose `toString()` returns the bounceable, URL-safe
-  WalletV4 address (synchronous).
+  address for the configured `walletVersion` (synchronous).
 - `_internals` — the primitives behind the above (`mnemonicNew`, `mnemonicToPrivateKey`,
-  `isBasicSeed`, `walletV4Address`, `cellHash`, `padBits`, `crc16`). Exported for testing and
-  advanced use; not yet covered by semver guarantees.
+  `isBasicSeed`, `walletAddress`, `walletV3R2Address`, `walletV4Address`, `walletV5R1Address`,
+  `cellHash`, `padBits`, `crc16`). Exported for testing and advanced use; not yet covered by
+  semver guarantees.
 
 TypeScript declarations are included (`index.d.ts`).
 
@@ -209,9 +227,10 @@ new TonWalletFinder('abc', false, true, false);
 new TonWalletFinder('abc', { showResult: true });
 ```
 
-It also adds a `walletVersion` option, reserved for upcoming `'v3r2'`/`'v5r1'` support.
-Today only `'v4r2'` (the existing default behaviour) is accepted — passing anything else
-throws at construction time.
+Version 5.1.0 adds **wallet version selection**: `walletVersion: 'v3r2' | 'v4r2' | 'v5r1'`.
+The default stays `'v4r2'`, so existing callers keep getting exactly the same addresses;
+`'v5r1'` (W5) is what current Tonkeeper / MyTonWallet create by default. See
+[Wallet versions](#wallet-versions).
 
 See [Migration from v4](#-migration-from-v4) below for the full breaking-change table.
 
@@ -245,7 +264,7 @@ The public API is identical — no code changes required when upgrading from v3.
 |---|---|---|
 | Constructor signature | `TonWalletFinder(targetEnding, showProcess, showResult, saveResult)` | `TonWalletFinder(targetEnding, { showProcess, showResult, saveResult, workers, walletVersion })` |
 | `workers` | `findWalletWithEnding({ workers })` only, default `1` | Also a constructor option (sets the default); `findWalletWithEnding({ workers })` still overrides it per call |
-| `walletVersion` | did not exist | New option, default `'v4r2'` (only supported value for now) |
+| `walletVersion` | did not exist | New option, default `'v4r2'`; `'v3r2'` / `'v5r1'` accepted since 5.1.0 |
 
 ### Migration checklist
 
@@ -271,8 +290,8 @@ The public API is identical — no code changes required when upgrading from v3.
    per-call override.
 
 3. **`walletVersion`** — nothing to do; it defaults to `'v4r2'`, which is what v4.x always
-   produced. It exists now only so it can be validated; `'v3r2'`/`'v5r1'` are not implemented
-   yet.
+   produced. Pass `'v3r2'` or `'v5r1'` only if that is the wallet type you will import the
+   mnemonic into.
 
 ---
 
@@ -386,7 +405,7 @@ new TonWalletFinder(targetEnding, {
   showResult,    // boolean
   saveResult,    // boolean
   workers,       // number | 'auto'
-  walletVersion, // 'v4r2'
+  walletVersion, // 'v3r2' | 'v4r2' | 'v5r1'
 });
 ```
 
@@ -397,7 +416,25 @@ new TonWalletFinder(targetEnding, {
 | `options.showResult` | `boolean` | `false` | Вывести найденный кошелёк в консоль. **Оставьте `false` в окружениях с логированием, чтобы не раскрывать приватный ключ.** |
 | `options.saveResult` | `boolean` | `false` | Сохранить результат в `ton_wallet_results.txt` в текущей рабочей директории. Существующий файл не перезаписывается: добавляется суффикс `-2`, `-3`, … |
 | `options.workers` | `number \| 'auto'` | `1` | Значение по умолчанию для числа воркеров в `findWalletWithEnding()` (см. [Производительность](#производительность)). Можно переопределить при вызове. |
-| `options.walletVersion` | `'v4r2'` | `'v4r2'` | Версия контракта TON-кошелька для деривации адреса. Пока поддерживается только `'v4r2'`; разные версии дают разные адреса из одной и той же мнемоники, поэтому значение должно совпадать с тем кошельком, в который вы будете импортировать мнемонику. |
+| `options.walletVersion` | `'v3r2' \| 'v4r2' \| 'v5r1'` | `'v4r2'` | Версия контракта TON-кошелька для деривации адреса — см. [Версии кошелька](#версии-кошелька). |
+
+#### Версии кошелька
+
+| `walletVersion` | Контракт | Примечания |
+|---|---|---|
+| `'v3r2'` | WalletV3R2 | Устаревший контракт, но импортируется большинством кошельков |
+| `'v4r2'` | WalletV4R2 | **По умолчанию.** Те же адреса, что и во всех предыдущих версиях библиотеки |
+| `'v5r1'` | WalletV5R1 (W5) | Текущий стандарт по умолчанию в Tonkeeper / MyTonWallet и др. Mainnet wallet id, subwallet 0 |
+
+> **Одна и та же мнемоника даёт разный адрес для каждой версии.** Найденный красивый адрес
+> существует только для той версии, с которой вы искали, поэтому `walletVersion` должен
+> совпадать с типом кошелька, в который вы импортируете 24 слова (и с версией, выбранной
+> в нём). Если не уверены — посмотрите, какой адрес ваш кошелёк показывает для уже
+> существующей сид-фразы.
+
+```javascript
+const finder = new TonWalletFinder('abc', { walletVersion: 'v5r1' });
+```
 
 ### API
 
@@ -459,10 +496,11 @@ const result = await finder.findWalletWithEnding({ workers: 4 });
 - `finder.createKeyPair()` → `Promise<{ keyPair: { publicKey, secretKey }, words }>` — новая
   24-словная TON-мнемоника и её пара ключей Ed25519.
 - `finder.createWallet(keyPair)` → объект, чей `toString()` возвращает bounceable URL-safe
-  адрес WalletV4 (синхронно).
+  адрес для выбранной `walletVersion` (синхронно).
 - `_internals` — примитивы, на которых всё построено (`mnemonicNew`, `mnemonicToPrivateKey`,
-  `isBasicSeed`, `walletV4Address`, `cellHash`, `padBits`, `crc16`). Экспортированы для тестов и
-  продвинутого использования; пока не покрыты гарантиями semver.
+  `isBasicSeed`, `walletAddress`, `walletV3R2Address`, `walletV4Address`, `walletV5R1Address`,
+  `cellHash`, `padBits`, `crc16`). Экспортированы для тестов и продвинутого использования; пока
+  не покрыты гарантиями semver.
 
 Поставляется с декларациями TypeScript (`index.d.ts`).
 
@@ -498,9 +536,10 @@ new TonWalletFinder('abc', false, true, false);
 new TonWalletFinder('abc', { showResult: true });
 ```
 
-Также добавлена опция `walletVersion`, зарезервированная под будущую поддержку
-`'v3r2'`/`'v5r1'`. Пока принимается только `'v4r2'` (нынешнее поведение по умолчанию) —
-любое другое значение вызывает исключение при создании экземпляра.
+В версии 5.1.0 добавлен **выбор версии кошелька**: `walletVersion: 'v3r2' | 'v4r2' | 'v5r1'`.
+По умолчанию остаётся `'v4r2'`, поэтому существующие вызовы получают ровно те же адреса;
+`'v5r1'` (W5) — то, что сейчас создают по умолчанию Tonkeeper / MyTonWallet. См.
+[Версии кошелька](#версии-кошелька).
 
 Полную таблицу breaking-изменений см. в разделе [Миграция с v4](#миграция-с-v4) ниже.
 
@@ -530,7 +569,7 @@ new TonWalletFinder('abc', { showResult: true });
 |---|---|---|
 | Сигнатура конструктора | `TonWalletFinder(targetEnding, showProcess, showResult, saveResult)` | `TonWalletFinder(targetEnding, { showProcess, showResult, saveResult, workers, walletVersion })` |
 | `workers` | только в `findWalletWithEnding({ workers })`, по умолчанию `1` | Также опция конструктора (задаёт значение по умолчанию); `findWalletWithEnding({ workers })` по-прежнему переопределяет его для конкретного вызова |
-| `walletVersion` | не существовала | Новая опция, по умолчанию `'v4r2'` (пока единственное поддерживаемое значение) |
+| `walletVersion` | не существовала | Новая опция, по умолчанию `'v4r2'`; `'v3r2'` / `'v5r1'` принимаются с 5.1.0 |
 
 #### Чек-лист миграции
 
@@ -556,8 +595,8 @@ new TonWalletFinder('abc', { showResult: true });
    нужно, это по-прежнему работает как переопределение для конкретного вызова.
 
 3. **`walletVersion`** — ничего делать не нужно; по умолчанию `'v4r2'`, то есть ровно то,
-   что v4.x всегда и производила. Опция появилась сейчас только для того, чтобы её можно
-   было валидировать; `'v3r2'`/`'v5r1'` пока не реализованы.
+   что v4.x всегда и производила. Передавайте `'v3r2'` или `'v5r1'` только если именно в
+   такой кошелёк вы будете импортировать мнемонику.
 
 ### Миграция с v2/v3
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,9 +14,11 @@ export interface WalletResult {
 
 /**
  * TON wallet contract version to derive the address for.
- * Currently only `'v4r2'` is implemented; other values are reserved for future releases.
+ * - `'v3r2'` — WalletV3R2 (legacy, still widely supported)
+ * - `'v4r2'` — WalletV4R2 (default)
+ * - `'v5r1'` — WalletV5R1 / W5 (mainnet wallet id, subwallet 0)
  */
-export type WalletVersion = 'v4r2';
+export type WalletVersion = 'v3r2' | 'v4r2' | 'v5r1';
 
 /**
  * Options accepted by the `TonWalletFinder` constructor.
@@ -67,7 +69,7 @@ export interface FindOptions {
 }
 
 /**
- * Searches for a TON WalletV4 address that ends with the given pattern.
+ * Searches for a TON wallet address (WalletV4R2 by default) that ends with the given pattern.
  *
  * @example
  * ```js
@@ -123,8 +125,8 @@ export declare class TonWalletFinder {
     createKeyPair(): Promise<{ keyPair: { publicKey: Uint8Array; secretKey: Uint8Array }; words: string[] }>;
 
     /**
-     * Derives the WalletV4 (workchain 0) address for a key pair and returns an
-     * address object. `toString()` always yields the bounceable, URL-safe form;
+     * Derives the address (workchain 0, contract version = `walletVersion`) for a key
+     * pair and returns an address object. `toString()` always yields the bounceable, URL-safe form;
      * the options argument is accepted for compatibility and ignored.
      * Synchronous — no I/O is performed.
      */
@@ -186,8 +188,14 @@ export declare const _internals: {
     mnemonicToPrivateKey(words: readonly string[]): Promise<Ed25519KeyPair>;
     /** TON "basic seed" check — `true` if the mnemonic is valid without a password. */
     isBasicSeed(words: readonly string[]): Promise<boolean>;
+    /** Bounceable, URL-safe address for a 32-byte public key and the given wallet version. */
+    walletAddress(version: WalletVersion, publicKey: Uint8Array, workchain?: number): string;
+    /** Bounceable, URL-safe WalletV3R2 address for a 32-byte public key. */
+    walletV3R2Address(publicKey: Uint8Array, workchain?: number): string;
     /** Bounceable, URL-safe WalletV4R2 address for a 32-byte public key. */
     walletV4Address(publicKey: Uint8Array, workchain?: number): string;
+    /** Bounceable, URL-safe WalletV5R1 (W5, mainnet wallet id) address for a 32-byte public key. */
+    walletV5R1Address(publicKey: Uint8Array, workchain?: number): string;
     /** TVM representation hash (SHA-256) of an ordinary cell. */
     cellHash(bitsCount: number, bitsBytes: Uint8Array, refs: ReadonlyArray<{ depth: number; hash: Uint8Array }>): Uint8Array;
     /** TVM bit padding: sets the completion bit after `bitsCount` data bits. */

--- a/index.js
+++ b/index.js
@@ -93,14 +93,35 @@ async function mnemonicToPrivateKey(words) {
 }
 
 // ---------------------------------------------------------------------------
-// WalletV4 address derivation (pure TVM cell hashing, no @ton/core)
+// Wallet address derivation (pure TVM cell hashing, no @ton/core)
 // ---------------------------------------------------------------------------
 
-// Pre-computed constants for the WalletV4R2 code cell (fixed bytecode).
+// Pre-computed constants for each wallet version's code cell (fixed bytecode).
 // hash = SHA-256 of the code cell repr; depth = max ref depth + 1.
-const CODE_HASH  = Buffer.from(
-    'feb5ff6820e2ff0d9483e7e0d62c817d846789fb4ae580c878866d959dabd5c0', 'hex');
-const CODE_DEPTH = 7;
+// Taken from @ton/ton's WalletContractV3R2 / WalletContractV4 / WalletContractV5R1
+// (`init.code.hash()` / `init.code.depth()`), pinned by test/crypto.test.js.
+const WALLET_CODE = {
+    v3r2: {
+        hash:  Buffer.from('84dafa449f98a6987789ba232358072bc0f76dc4524002a5d0918b9a75d2d599', 'hex'),
+        depth: 0,
+    },
+    v4r2: {
+        hash:  Buffer.from('feb5ff6820e2ff0d9483e7e0d62c817d846789fb4ae580c878866d959dabd5c0', 'hex'),
+        depth: 7,
+    },
+    v5r1: {
+        hash:  Buffer.from('20834b7b72b112147e1b2fb457b84e74d1a30f04f737d4f62a668e9552d2b72f', 'hex'),
+        depth: 6,
+    },
+};
+
+// subwallet_id shared by the v3 and v4 wallet contracts (698983191 = 0x29a9a317).
+const DEFAULT_SUBWALLET_ID = 698983191;
+
+// W5 wallet_id is not a flat constant: it is a 32-bit "client context"
+// (1 | workchain:int8 | wallet_version:uint8 | subwallet_number:uint15) XOR'ed
+// with the network global id. Mainnet global id is -239; W5 v5r1 version byte is 0.
+const V5R1_NETWORK_GLOBAL_ID = -239;
 
 /**
  * Compute the TVM-standard SHA-256 hash of a single ordinary cell.
@@ -161,26 +182,24 @@ function crc16(data) {
 }
 
 /**
- * Derive a WalletV4 (workchain 0) address from a 32-byte Ed25519 public key.
- * Returns a bounceable, URL-safe base64 string (48 chars).
+ * Hash a StateInit { code, data } (no split_depth / special / library) and
+ * encode the resulting account id as a bounceable, URL-safe address (48 chars).
+ *
+ * @param {{ hash: Buffer, depth: number }} code   - pre-computed code cell constants
+ * @param {number} dataBits                        - data cell length in bits
+ * @param {Buffer} dataBuf                         - data cell bits, unpadded
+ * @param {number} workchain
  */
-function walletV4Address(pubkey, workchain = 0) {
-    const subwalletId = 698983191 + workchain;
-
-    // ---- Data cell: seqno(32) | subwallet_id(32) | pubkey(256) | has_plugins(1) ----
-    // Total = 321 bits; has_plugins = 0, padBits() sets the trailing "1" completion bit.
-    const dataBuf = Buffer.alloc(41, 0);
-    dataBuf.writeUInt32BE(0,           0);  // seqno
-    dataBuf.writeUInt32BE(subwalletId, 4);  // subwallet_id
-    dataBuf.set(pubkey, 8);                 // 32 bytes public key
-    const dataHash  = cellHash(321, padBits(321, dataBuf), []);
+function stateInitAddress(code, dataBits, dataBuf, workchain) {
+    // The data cells of all supported wallets have no refs, so their depth is 0.
+    const dataHash  = cellHash(dataBits, padBits(dataBits, dataBuf), []);
     const dataDepth = 0;
 
     // ---- StateInit cell: bits = 00110 (5 bits), refs = [code, data] ----
     // 00110 padded => 00110_100 = 0x34
     const siPadded = padBits(5, Buffer.from([0b00110000]));
     const siHash   = cellHash(5, siPadded, [
-        { depth: CODE_DEPTH, hash: CODE_HASH },
+        { depth: code.depth, hash: code.hash },
         { depth: dataDepth,  hash: dataHash  },
     ]);
 
@@ -197,6 +216,80 @@ function walletV4Address(pubkey, workchain = 0) {
     return addr.toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
 }
 
+/**
+ * Derive a WalletV3R2 address from a 32-byte Ed25519 public key.
+ * Returns a bounceable, URL-safe base64 string (48 chars).
+ */
+function walletV3R2Address(pubkey, workchain = 0) {
+    // ---- Data cell: seqno(32) | subwallet_id(32) | pubkey(256) = 320 bits (byte-aligned) ----
+    const dataBuf = Buffer.alloc(40, 0);
+    dataBuf.writeUInt32BE(0,                                   0);  // seqno
+    dataBuf.writeUInt32BE(DEFAULT_SUBWALLET_ID + workchain,    4);  // subwallet_id
+    dataBuf.set(pubkey, 8);                                         // 32 bytes public key
+    return stateInitAddress(WALLET_CODE.v3r2, 320, dataBuf, workchain);
+}
+
+/**
+ * Derive a WalletV4R2 address from a 32-byte Ed25519 public key.
+ * Returns a bounceable, URL-safe base64 string (48 chars).
+ */
+function walletV4Address(pubkey, workchain = 0) {
+    // ---- Data cell: seqno(32) | subwallet_id(32) | pubkey(256) | has_plugins(1) ----
+    // Total = 321 bits; has_plugins = 0, padBits() sets the trailing "1" completion bit.
+    const dataBuf = Buffer.alloc(41, 0);
+    dataBuf.writeUInt32BE(0,                                   0);  // seqno
+    dataBuf.writeUInt32BE(DEFAULT_SUBWALLET_ID + workchain,    4);  // subwallet_id
+    dataBuf.set(pubkey, 8);                                         // 32 bytes public key
+    return stateInitAddress(WALLET_CODE.v4r2, 321, dataBuf, workchain);
+}
+
+/**
+ * Derive a WalletV5R1 (W5) address from a 32-byte Ed25519 public key.
+ * Returns a bounceable, URL-safe base64 string (48 chars).
+ */
+function walletV5R1Address(pubkey, workchain = 0) {
+    // wallet_id = client_context XOR network_global_id, both as int32.
+    // client_context = 1 | workchain:int8 | wallet_version:uint8 (0 = v5r1) | subwallet_number:uint15 (0)
+    const context  = (0x80000000 | ((workchain & 0xff) << 23)) >>> 0;
+    const walletId = (context ^ V5R1_NETWORK_GLOBAL_ID) >>> 0;
+
+    // ---- Data cell: is_signature_allowed(1) | seqno(32) | wallet_id(32) | pubkey(256) | extensions(1) ----
+    // Total = 322 bits. Everything after the leading "1" bit is shifted right by one bit,
+    // so assemble the byte-aligned tail first and then shift it into place.
+    const tail = Buffer.alloc(40, 0);
+    tail.writeUInt32BE(0,        0);  // seqno
+    tail.writeUInt32BE(walletId, 4);  // wallet_id
+    tail.set(pubkey, 8);              // 32 bytes public key
+
+    const dataBuf = Buffer.alloc(41, 0);
+    dataBuf[0] = 0x80;                // is_signature_allowed = 1
+    for (let i = 0; i < 40; i++) {
+        dataBuf[i]     |= tail[i] >> 1;
+        dataBuf[i + 1] |= (tail[i] & 0x01) << 7;
+    }
+    // Bit 321 (extensions dict = empty) is already 0; padBits() adds the completion bit after it.
+    return stateInitAddress(WALLET_CODE.v5r1, 322, dataBuf, workchain);
+}
+
+const WALLET_ADDRESS_BY_VERSION = {
+    v3r2: walletV3R2Address,
+    v4r2: walletV4Address,
+    v5r1: walletV5R1Address,
+};
+
+/**
+ * Derive the address for a given wallet version. Different versions produce
+ * different addresses from the same key — the version must match the wallet
+ * software the mnemonic will be imported into.
+ */
+function walletAddress(version, pubkey, workchain = 0) {
+    const derive = WALLET_ADDRESS_BY_VERSION[version];
+    if (!derive) {
+        throw new Error(`Unsupported wallet version: ${JSON.stringify(version)}`);
+    }
+    return derive(pubkey, workchain);
+}
+
 // ---------------------------------------------------------------------------
 // TonWalletFinder
 // ---------------------------------------------------------------------------
@@ -209,9 +302,9 @@ const MAX_TARGET_LENGTH = 46;
 // Transient errors are retried; a persistent one must not spin forever.
 const MAX_CONSECUTIVE_ERRORS = 5;
 
-// Only wallet version implemented so far; validated eagerly so a typo fails at
-// construction time instead of producing an address for the wrong wallet.
-const SUPPORTED_WALLET_VERSIONS = ['v4r2'];
+// Validated eagerly so a typo fails at construction time instead of producing
+// an address for the wrong wallet.
+const SUPPORTED_WALLET_VERSIONS = Object.keys(WALLET_ADDRESS_BY_VERSION);
 
 class TonWalletFinder {
     /**
@@ -223,8 +316,9 @@ class TonWalletFinder {
      * @param {boolean} [options.saveResult=false]   - Save result to ton_wallet_results.txt
      * @param {number|'auto'} [options.workers=1]    - Default worker count for `findWalletWithEnding()`;
      *        overridable per call. See `findWalletWithEnding` for the accepted values.
-     * @param {'v4r2'} [options.walletVersion='v4r2'] - TON wallet contract version to derive
-     *        the address for. Currently only `'v4r2'` is supported.
+     * @param {'v3r2'|'v4r2'|'v5r1'} [options.walletVersion='v4r2'] - TON wallet contract
+     *        version to derive the address for. Different versions give different addresses
+     *        for the same mnemonic.
      */
     constructor(targetEnding, options = {}) {
         // Dash at end of character class avoids ambiguous range
@@ -268,11 +362,11 @@ class TonWalletFinder {
         return { keyPair, words };
     }
 
-    // Derive a WalletV4 address from a key pair.
+    // Derive the wallet address (for this.walletVersion) from a key pair.
     // Returns an address object with a .toString() method — same interface as
     // the original @ton/core Address so callers are unaffected.
     createWallet(keyPair) {
-        const str = walletV4Address(Buffer.from(keyPair.publicKey));
+        const str = walletAddress(this.walletVersion, Buffer.from(keyPair.publicKey));
         return { toString: () => str };
     }
 
@@ -362,7 +456,11 @@ class TonWalletFinder {
             if (signal) { signal.addEventListener('abort', onAbort, { once: true }); }
 
             for (let i = 0; i < count; i++) {
-                const w = this._createWorker({ targetEnding: this.targetEnding, showProcess: this.showProcess });
+                const w = this._createWorker({
+                    targetEnding:  this.targetEnding,
+                    showProcess:   this.showProcess,
+                    walletVersion: this.walletVersion,
+                });
                 workers.push(w);
 
                 w.on('message', msg => {
@@ -518,7 +616,10 @@ module.exports._internals = {
     mnemonicNew,
     mnemonicToPrivateKey,
     isBasicSeed,
+    walletAddress,
+    walletV3R2Address,
     walletV4Address,
+    walletV5R1Address,
     cellHash,
     padBits,
     crc16,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ton-wallet-finder",
-  "version": "4.1.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ton-wallet-finder",
-      "version": "4.1.0",
+      "version": "5.1.0",
       "funding": [
         {
           "type": "cryptocurrency",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ton-wallet-finder",
-  "version": "5.0.0",
-  "description": "Vanity address generator for TON blockchain — find a WalletV4 address ending with any custom string.",
+  "version": "5.1.0",
+  "description": "Vanity address generator for TON blockchain — find a wallet address (v3r2 / v4r2 / v5r1) ending with any custom string.",
   "main": "index.js",
   "exports": {
     ".": {

--- a/test/TonWalletFinder.test.js
+++ b/test/TonWalletFinder.test.js
@@ -106,9 +106,16 @@ describe('TonWalletFinder', () => {
             expect(finder.workers).to.equal('auto');
         });
 
+        it('should accept every supported walletVersion', () => {
+            for (const v of ['v3r2', 'v4r2', 'v5r1']) {
+                const finder = new TonWalletFinder('x', { walletVersion: v });
+                expect(finder.walletVersion).to.equal(v);
+            }
+        });
+
         it('should throw on an unsupported walletVersion', () => {
-            expect(() => new TonWalletFinder('x', { walletVersion: 'v3r2' })).to.throw(Error, /walletVersion/);
-            expect(() => new TonWalletFinder('x', { walletVersion: 'v5r1' })).to.throw(Error, /walletVersion/);
+            expect(() => new TonWalletFinder('x', { walletVersion: 'v4' })).to.throw(Error, /walletVersion/);
+            expect(() => new TonWalletFinder('x', { walletVersion: 'V4R2' })).to.throw(Error, /walletVersion/);
             expect(() => new TonWalletFinder('x', { walletVersion: 'bogus' })).to.throw(Error, /walletVersion/);
         });
     });
@@ -164,6 +171,15 @@ describe('TonWalletFinder', () => {
             const str = address.toString({ urlSafe: true, bounceable: true });
             expect(str).to.match(/^(EQ|UQ)/);
             expect(str).to.have.lengthOf(48);
+        });
+
+        it('should derive the address for the configured walletVersion', async () => {
+            const { walletV3R2Address, walletV4Address, walletV5R1Address } = require('../index')._internals;
+            const { keyPair } = await new TonWalletFinder('a').createKeyPair();
+            const pubkey = Buffer.from(keyPair.publicKey);
+            expect(new TonWalletFinder('a', { walletVersion: 'v3r2' }).createWallet(keyPair).toString()).to.equal(walletV3R2Address(pubkey));
+            expect(new TonWalletFinder('a').createWallet(keyPair).toString()).to.equal(walletV4Address(pubkey));
+            expect(new TonWalletFinder('a', { walletVersion: 'v5r1' }).createWallet(keyPair).toString()).to.equal(walletV5R1Address(pubkey));
         });
     });
 

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -3,9 +3,15 @@
 const { expect } = require('chai');
 const { _internals } = require('../index');
 
-const { mnemonicToPrivateKey, isBasicSeed, walletV4Address, cellHash, padBits, crc16 } = _internals;
+const {
+    mnemonicToPrivateKey, isBasicSeed,
+    walletAddress, walletV3R2Address, walletV4Address, walletV5R1Address,
+    cellHash, padBits, crc16,
+} = _internals;
 
-// Reference vector generated with @ton/crypto 3.3 + @ton/ton 16.2 (WalletContractV4, workchain 0).
+// Reference vector generated with @ton/crypto 3.3 + @ton/ton 16.x (workchain 0):
+// WalletContractV4 for `address` (16.2), WalletContractV3R2 / WalletContractV5R1
+// for `addressV3R2` / `addressV5R1` (16.3, default mainnet wallet id).
 // Any change to the mnemonic derivation, cell hashing, padding, CRC or address
 // encoding must keep this test green — otherwise generated addresses would no
 // longer belong to the generated mnemonic.
@@ -13,6 +19,8 @@ const VECTOR = {
     words: 'tip sadness bid sleep want jaguar upset just crack kid possible heart exclude figure sadness alter feel expect wide have column seek win churn'.split(' '),
     publicKey: 'f46e86acef393f1546d1f68b2bb090e1a2ed4f3edc112e1e87726364363ad355',
     address: 'EQCPi7yyyv6aDR8jY38B_PH9wSaMc8NTNEAGgQlnHW_BP3KC',
+    addressV3R2: 'EQBFytd2exhHu6RoGzTRcMQknLVp_9yLt1tqYNFZ_W0JvCma',
+    addressV5R1: 'EQBeV0gSMYJ-nN8fj5DGGfJ-AbseVanoTAq0JgiutlBXsS3c',
 };
 
 describe('crypto primitives (reference vectors)', () => {
@@ -78,6 +86,57 @@ describe('crypto primitives (reference vectors)', () => {
             const raw  = Buffer.from(addr.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
             expect(raw[0]).to.equal(0x11);
             expect(raw.readInt8(1)).to.equal(-1);
+        });
+    });
+
+    describe('walletV3R2Address()', () => {
+        it('should produce the reference address from the reference public key', () => {
+            const addr = walletV3R2Address(Buffer.from(VECTOR.publicKey, 'hex'));
+            expect(addr).to.equal(VECTOR.addressV3R2);
+        });
+
+        it('should accept a plain Uint8Array public key (not only Buffer)', () => {
+            const plain = new Uint8Array(Buffer.from(VECTOR.publicKey, 'hex'));
+            expect(walletV3R2Address(plain)).to.equal(VECTOR.addressV3R2);
+        });
+
+        it('should produce a 48-char base64url string with no padding', () => {
+            expect(walletV3R2Address(Buffer.alloc(32, 7))).to.match(/^[A-Za-z0-9_-]{48}$/);
+        });
+    });
+
+    describe('walletV5R1Address()', () => {
+        it('should produce the reference address from the reference public key', () => {
+            const addr = walletV5R1Address(Buffer.from(VECTOR.publicKey, 'hex'));
+            expect(addr).to.equal(VECTOR.addressV5R1);
+        });
+
+        it('should accept a plain Uint8Array public key (not only Buffer)', () => {
+            const plain = new Uint8Array(Buffer.from(VECTOR.publicKey, 'hex'));
+            expect(walletV5R1Address(plain)).to.equal(VECTOR.addressV5R1);
+        });
+
+        it('should produce a 48-char base64url string with no padding', () => {
+            expect(walletV5R1Address(Buffer.alloc(32, 7))).to.match(/^[A-Za-z0-9_-]{48}$/);
+        });
+    });
+
+    describe('walletAddress()', () => {
+        const pubkey = Buffer.from(VECTOR.publicKey, 'hex');
+
+        it('should dispatch to the per-version derivation', () => {
+            expect(walletAddress('v3r2', pubkey)).to.equal(VECTOR.addressV3R2);
+            expect(walletAddress('v4r2', pubkey)).to.equal(VECTOR.address);
+            expect(walletAddress('v5r1', pubkey)).to.equal(VECTOR.addressV5R1);
+        });
+
+        it('should give three different addresses for the same key', () => {
+            const all = new Set([VECTOR.addressV3R2, VECTOR.address, VECTOR.addressV5R1]);
+            expect(all.size).to.equal(3);
+        });
+
+        it('should throw on an unknown version', () => {
+            expect(() => walletAddress('v2r2', pubkey)).to.throw(Error, /Unsupported wallet version/);
         });
     });
 

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -105,10 +105,10 @@ describe('findWalletWithEnding({ workers })', () => {
 
         afterEach(() => sinon.restore());
 
-        it('should spawn exactly `workers` workers with targetEnding and showProcess', async () => {
+        it('should spawn exactly `workers` workers with targetEnding, showProcess and walletVersion', async () => {
             const p = finder.findWalletWithEnding({ workers: 3 });
             expect(spawned).to.have.lengthOf(3);
-            expect(spawned[0].workerData).to.deep.equal({ targetEnding: 'A', showProcess: false });
+            expect(spawned[0].workerData).to.deep.equal({ targetEnding: 'A', showProcess: false, walletVersion: 'v4r2' });
             spawned[1].emit('message', {
                 type: 'found', publicKey: Buffer.alloc(32, 1), secretKey: Buffer.alloc(64, 2),
                 words: Array(24).fill('abandon'), address: 'EQ' + 'A'.repeat(46),
@@ -239,6 +239,15 @@ describe('findWalletWithEnding({ workers })', () => {
             const finder = new TonWalletFinder('A');
             const result = await finder.findWalletWithEnding({ workers: 'auto' });
             expect(result.walletAddress.endsWith('A')).to.equal(true);
+        });
+
+        it('should pass walletVersion through to the workers (v5r1 result re-derives on the main thread)', async function () {
+            this.timeout(60000);
+            const finder = new TonWalletFinder('A', { walletVersion: 'v5r1' });
+            const result = await finder.findWalletWithEnding({ workers: 2 });
+            expect(result.walletAddress.endsWith('A')).to.equal(true);
+            const { walletV5R1Address } = require('../index')._internals;
+            expect(walletV5R1Address(Buffer.from(result.publicKey, 'hex'))).to.equal(result.walletAddress);
         });
     });
 });

--- a/worker.js
+++ b/worker.js
@@ -12,12 +12,12 @@
 const { parentPort, workerData, isMainThread } = require('worker_threads');
 const { _internals } = require('./index');
 
-const { mnemonicNew, mnemonicToPrivateKey, walletV4Address } = _internals;
+const { mnemonicNew, mnemonicToPrivateKey, walletAddress } = _internals;
 
 // Same policy as the single-threaded loop in index.js.
 const MAX_CONSECUTIVE_ERRORS = 5;
 
-async function searchLoop({ targetEnding, showProcess }) {
+async function searchLoop({ targetEnding, showProcess, walletVersion }) {
     let consecutiveErrors = 0;
     while (true) {
         let keyPair;
@@ -26,7 +26,7 @@ async function searchLoop({ targetEnding, showProcess }) {
         try {
             words   = await mnemonicNew();
             keyPair = await mnemonicToPrivateKey(words);
-            address = walletV4Address(keyPair.publicKey);
+            address = walletAddress(walletVersion, keyPair.publicKey);
             consecutiveErrors = 0;
         } catch (err) {
             consecutiveErrors++;


### PR DESCRIPTION
## Summary

Second step of the [v5 roadmap](ROADMAP.md), following #17: `walletVersion` now accepts `'v3r2'` and `'v5r1'` in addition to `'v4r2'`. The default stays `'v4r2'`, so existing callers get byte-identical addresses — this is an additive change, hence a minor bump to **5.1.0**.

- **`walletV3R2Address`** — data cell `seqno | subwallet_id | pubkey` (320 bits), code depth 0.
- **`walletV5R1Address`** (W5) — data cell `is_signature_allowed | seqno | wallet_id | pubkey | extensions` (322 bits), code depth 6. `wallet_id` is the mainnet client context (workchain 0, version byte 0, subwallet 0) XOR the network global id `-239`, exactly as `@ton/ton`'s `storeWalletIdV5R1` builds it (`0x7FFFFF11` for workchain 0).
- Address derivation refactored around a shared `stateInitAddress()` helper; `walletV4Address` is unchanged and still pinned by the existing vector.
- `createWallet()` dispatches on `this.walletVersion`; worker threads receive `walletVersion` through `workerData` and derive the same address as the main thread.
- `_internals` gains `walletAddress(version, pubkey)`, `walletV3R2Address`, `walletV5R1Address`; `index.d.ts` `WalletVersion` is `'v3r2' | 'v4r2' | 'v5r1'`.
- README (EN + RU): one row per version, a "Wallet versions" table, and the note that the same mnemonic yields a different address per version, so the option must match the wallet the seed will be imported into. CHANGELOG `[5.1.0]` entry.

## Reference vectors (roadmap's non-negotiable)

Constants were **not** hand-derived. `@ton/ton@16.3.0` + `@ton/crypto@3.3.0` were installed in a scratch directory (not added to the project) and run against the existing reference mnemonic:

| Version | Address | Code hash | Depth |
|---|---|---|---|
| V3R2 | `EQBFytd2exhHu6RoGzTRcMQknLVp_9yLt1tqYNFZ_W0JvCma` | `84dafa44…d599` | 0 |
| V4R2 (unchanged) | `EQCPi7yyyv6aDR8jY38B_PH9wSaMc8NTNEAGgQlnHW_BP3KC` | `feb5ff68…d5c0` | 7 |
| V5R1 | `EQBeV0gSMYJ-nN8fj5DGGfJ-AbseVanoTAq0JgiutlBXsS3c` | `20834b7b…b72f` | 6 |

All three are asserted in `test/crypto.test.js`; the V4R2 run also re-confirmed the existing constants, validating the method.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (100 tests): new reference-vector tests for V3R2/V5R1, `walletAddress()` dispatch + unknown-version throw, constructor accepts all three versions and rejects `'v4'`/`'V4R2'`, `createWallet()` matches the per-version primitive, worker `workerData` carries `walletVersion`, and a real 2-worker `v5r1` search whose result re-derives to the same address on the main thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUr81eUXLhV8VCwKnHEt5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUr81eUXLhV8VCwKnHEt5w)_