### PR TITLE
5.1.1: expose ./package.json in the exports map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.1.1] — 2026-09-06
+
+### Fixed
+- `require('ton-wallet-finder/package.json')` (and the ESM equivalent) failed with
+  `ERR_PACKAGE_PATH_NOT_EXPORTED` because the `exports` map only listed `"."`. The map now
+  also exposes `./package.json`, which bundlers, version checkers and other tooling read.
+  No other subpath is exported; the public API is unchanged.
+
+---
+
 ## [5.1.0] — 2026-09-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ton-wallet-finder",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ton-wallet-finder",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "funding": [
         {
           "type": "cryptocurrency",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ton-wallet-finder",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Vanity address generator for TON blockchain — find a wallet address (v3r2 / v4r2 / v5r1) ending with any custom string.",
   "main": "index.js",
   "exports": {
@@ -9,7 +9,8 @@
       "import": "./index.js",
       "require": "./index.js",
       "default": "./index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "files": [

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -31,6 +31,21 @@ describe('crypto primitives (reference vectors)', () => {
             expect(pkg.TonWalletFinder).to.be.a('function');
             expect(pkg.saveResultsToFile).to.be.a('function');
         });
+
+        it('should expose package.json through the exports map', () => {
+            // Tooling (bundlers, version checkers) reads this subpath; without an
+            // explicit entry Node rejects it with ERR_PACKAGE_PATH_NOT_EXPORTED.
+            const manifest = require('ton-wallet-finder/package.json');
+            expect(manifest.name).to.equal('ton-wallet-finder');
+            expect(manifest.version).to.equal(require('../package.json').version);
+        });
+
+        it('should not expose other internal files as subpaths', () => {
+            let err;
+            try { require('ton-wallet-finder/wordlist.js'); } catch (e) { err = e; }
+            expect(err, 'wordlist.js must not be reachable as a subpath').to.be.instanceOf(Error);
+            expect(err.code).to.equal('ERR_PACKAGE_PATH_NOT_EXPORTED');
+        });
     });
 
     describe('mnemonicToPrivateKey()', () => {

--- a/test/esm.test.mjs
+++ b/test/esm.test.mjs
@@ -1,6 +1,8 @@
 // Regression test for the "exports" map: the package must be importable from
 // ES modules. Uses Node's package self-reference, so this goes through the
 // exact same resolution a consumer's `import ... from 'ton-wallet-finder'` does.
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 import chai from 'chai';
 import * as ns from 'ton-wallet-finder';
 import pkg, { TonWalletFinder, saveResultsToFile } from 'ton-wallet-finder';
@@ -25,5 +27,14 @@ describe('ESM import', () => {
     it('should construct a finder', () => {
         const finder = new TonWalletFinder('abc');
         expect(finder.targetEnding).to.equal('abc');
+    });
+
+    it('should expose package.json through the exports map', () => {
+        // ESM resolution through the exports map (throws ERR_PACKAGE_PATH_NOT_EXPORTED
+        // if the subpath is missing), then read the file it points at.
+        const resolved = import.meta.resolve('ton-wallet-finder/package.json');
+        const manifest = JSON.parse(readFileSync(fileURLToPath(resolved), 'utf8'));
+        expect(manifest.name).to.equal('ton-wallet-finder');
+        expect(manifest.exports['./package.json']).to.equal('./package.json');
     });
 });


### PR DESCRIPTION
## Summary

Patch release. `require('ton-wallet-finder/package.json')` and its ESM equivalent failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` because the `exports` map only listed `"."`. Bundlers, version checkers and similar tooling read this subpath, so the map now also exposes `./package.json`.

Found while smoke-testing the published 5.1.0 tarball from a consumer project.

- `package.json`: `"./package.json": "./package.json"` added to `exports`; version → `5.1.1`.
- No other subpath is exposed — `wordlist.js`, `worker.js` etc. remain internal. Public API unchanged.
- `CHANGELOG.md`: `[5.1.1]` entry.

## Tests

- CJS: `require('ton-wallet-finder/package.json')` through the package self-reference resolves and matches the local manifest version.
- ESM: `import.meta.resolve('ton-wallet-finder/package.json')` resolves through the exports map (plain ES2020 syntax, so no ESLint `ecmaVersion` change was needed).
- Negative: `require('ton-wallet-finder/wordlist.js')` still throws with `code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'` — the fix does not widen the exported surface.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (103 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUr81eUXLhV8VCwKnHEt5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUr81eUXLhV8VCwKnHEt5w)_